### PR TITLE
Bump modmath 03 with zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
-modmath = { version = "0.2.0", optional = true, default-features = false, features = ["wide-mul"] }
+modmath = { version = "0.3.0", optional = true, default-features = false, features = ["wide-mul"] }
 fixed-bigint = { version = "0.3.0", optional = true, default-features = false, features = ["zeroize", "use-unsafe"] }
 subtle = { version = "2.6", default-features = false }
 heapless = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
-modmath = { version = "0.3.0", optional = true, default-features = false, features = ["wide-mul"] }
+modmath = { version = "0.3.0", optional = true, default-features = false, features = ["wide-mul", "zeroize"] }
 fixed-bigint = { version = "0.3.0", optional = true, default-features = false, features = ["zeroize", "use-unsafe"] }
 subtle = { version = "2.6", default-features = false }
 heapless = "0.9"

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -368,6 +368,19 @@ where
     params: ModMathParams<T, P>,
 }
 
+// `integer_mont` carries secret-derived Montgomery state (e.g. the plaintext
+// during encryption). `params` holds only the public modulus + Montgomery
+// constants, so we leave it untouched. Wrap a `ModMathForm` in
+// `zeroize::Zeroizing<_>` for automatic wipe on drop.
+impl<T, P: Personality> Zeroize for ModMathForm<T, P>
+where
+    T: Clone + Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.integer_mont.zeroize();
+    }
+}
+
 impl<T: ModMathInt> IntoMontyForm<ModMathParams<T, Nct>> for ModMathForm<T, Nct> {
     fn from_reduced(integer: ModMathValue<T>, params: &ModMathParams<T, Nct>) -> Self {
         let field = params.field();

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -373,7 +373,7 @@ impl<T: ModMathInt> IntoMontyForm<ModMathParams<T, Nct>> for ModMathForm<T, Nct>
         let field = params.field();
         let r = field.reduce(unwrap_value_ref(&integer));
         Self {
-            integer_mont: wrap_value(r.mont_value()),
+            integer_mont: wrap_value(*r.mont_value()),
             params: params.clone(),
         }
     }
@@ -390,7 +390,7 @@ impl<T: ModMathInt> ModMathForm<T, Nct> {
     fn pow_loop(&self, exp_raw: T) -> T {
         let field = self.params.field();
         let base = field.residue_from_mont(unwrap_value(&self.integer_mont));
-        field.exp(&base, &exp_raw).mont_value()
+        *field.exp(&base, &exp_raw).mont_value()
     }
 
     fn to_reduced(&self) -> T {
@@ -444,7 +444,7 @@ impl<T: ModMathIntCt> IntoMontyForm<ModMathParams<T, Ct>> for ModMathForm<T, Ct>
         let field = params.field();
         let r = field.reduce(unwrap_value_ref(&integer));
         Self {
-            integer_mont: wrap_value(r.mont_value()),
+            integer_mont: wrap_value(*r.mont_value()),
             params: params.clone(),
         }
     }
@@ -460,7 +460,7 @@ impl<T: ModMathIntCt> ModMathForm<T, Ct> {
     fn pow_loop(&self, exp_raw: T) -> T {
         let field = self.params.field();
         let base = field.residue_from_mont(unwrap_value(&self.integer_mont));
-        field.exp_public_exp(&base, &exp_raw).mont_value()
+        *field.exp_public_exp(&base, &exp_raw).mont_value()
     }
 
     fn to_reduced(&self) -> T {


### PR DESCRIPTION
## Summary by Sourcery

Bump the modmath dependency to 0.3.0 with zeroize support and adapt modular arithmetic helpers to the updated API.

New Features:
- Enable zeroize support in the modmath dependency for secure big-integer handling.

Enhancements:
- Adjust modular arithmetic conversions and exponentiation helpers to work with the updated modmath 0.3.0 API.

Build:
- Update Cargo.toml to use modmath 0.3.0 with the zeroize feature enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated optional modmath dependency to a newer version and enabled its additional security feature.

* **Refactor**
  * Adjusted Montgomery-form arithmetic paths to be compatible with the dependency update.

* **New Features**
  * Added secure zeroization to wipe sensitive Montgomery-form internal data on drop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->