### PR TITLE
Auto-wipe ModMathForm on drop

### DIFF
--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -359,6 +359,8 @@ where
     Ok(rsa_encrypt(key, &input)?.to_be_bytes())
 }
 
+// `T: Zeroize` (not just `Clone`) is locked in to satisfy `Drop` coherence
+// below — loosening it silently disables the auto-wipe.
 #[derive(Clone, Debug)]
 pub struct ModMathForm<T, P: Personality = Nct>
 where
@@ -368,12 +370,7 @@ where
     params: ModMathParams<T, P>,
 }
 
-// `integer_mont` carries secret-derived Montgomery state (e.g. the plaintext
-// during encryption). `params` holds only the public modulus + Montgomery
-// constants, so we leave it untouched. The `Drop` impl wipes automatically;
-// `ZeroizeOnDrop` is the marker the trait expects callers to be able to rely
-// on. Bounds on `Drop` must match the struct's, hence `T: Zeroize` in the
-// struct definition above (already implied by `ModMathInt` / `ModMathIntCt`).
+// `integer_mont` is secret-derived Montgomery state; `params` is public.
 impl<T, P: Personality> Zeroize for ModMathForm<T, P>
 where
     T: Clone + Zeroize,
@@ -388,7 +385,7 @@ where
     T: Clone + Zeroize,
 {
     fn drop(&mut self) {
-        self.integer_mont.zeroize();
+        self.zeroize();
     }
 }
 

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -362,7 +362,7 @@ where
 #[derive(Clone, Debug)]
 pub struct ModMathForm<T, P: Personality = Nct>
 where
-    T: Clone,
+    T: Clone + Zeroize,
 {
     integer_mont: ModMathValue<T>,
     params: ModMathParams<T, P>,
@@ -370,8 +370,10 @@ where
 
 // `integer_mont` carries secret-derived Montgomery state (e.g. the plaintext
 // during encryption). `params` holds only the public modulus + Montgomery
-// constants, so we leave it untouched. Wrap a `ModMathForm` in
-// `zeroize::Zeroizing<_>` for automatic wipe on drop.
+// constants, so we leave it untouched. The `Drop` impl wipes automatically;
+// `ZeroizeOnDrop` is the marker the trait expects callers to be able to rely
+// on. Bounds on `Drop` must match the struct's, hence `T: Zeroize` in the
+// struct definition above (already implied by `ModMathInt` / `ModMathIntCt`).
 impl<T, P: Personality> Zeroize for ModMathForm<T, P>
 where
     T: Clone + Zeroize,
@@ -380,6 +382,17 @@ where
         self.integer_mont.zeroize();
     }
 }
+
+impl<T, P: Personality> Drop for ModMathForm<T, P>
+where
+    T: Clone + Zeroize,
+{
+    fn drop(&mut self) {
+        self.integer_mont.zeroize();
+    }
+}
+
+impl<T, P: Personality> zeroize::ZeroizeOnDrop for ModMathForm<T, P> where T: Clone + Zeroize {}
 
 impl<T: ModMathInt> IntoMontyForm<ModMathParams<T, Nct>> for ModMathForm<T, Nct> {
     fn from_reduced(integer: ModMathValue<T>, params: &ModMathParams<T, Nct>) -> Self {
@@ -530,7 +543,8 @@ mod tests {
     use signature::hazmat::PrehashVerifier;
 
     use super::{
-        public_key_ct_from_be_bytes, public_key_from_be_bytes, ModMathParams, ModMathValue,
+        public_key_ct_from_be_bytes, public_key_from_be_bytes, ModMathForm, ModMathParams,
+        ModMathValue,
     };
     use crate::key::GenericRsaPublicKey;
     use crate::pkcs1v15::{GenericEncryptingKey, GenericSignature, GenericVerifyingKey};
@@ -583,6 +597,13 @@ mod tests {
         let _ = nct.to_be_bytes(&mut nct_bytes);
         let _ = ct.to_be_bytes(&mut ct_bytes);
         assert_eq!(nct_bytes, ct_bytes);
+    }
+
+    #[test]
+    fn mod_math_form_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {}
+        assert_zeroize_on_drop::<ModMathForm<SmallU>>();
+        assert_zeroize_on_drop::<ModMathForm<SmallUCt, Ct>>();
     }
 
     #[test]


### PR DESCRIPTION
PR #16 added `impl Zeroize for ModMathForm` but required callers to wrap in `Zeroizing<>` for auto-wipe. The upstream-aligned encrypt path in `algorithms/rsa.rs` doesn't do that (and we don't want to diverge), so a secret-derived `ModMathForm` (e.g. the padded message in Montgomery form during encryption) lingered on the stack after `pow_mod_params_vartime_exp_bits` returned.

Add `Drop` + `ZeroizeOnDrop` so the wipe happens automatically. Rust drop coherence requires the `Drop` impl bounds to match the struct's, so the struct's `T: Clone` is tightened to `T: Clone + Zeroize`. That's a no-op functionally: `ModMathInt` and `ModMathIntCt` both extend `FixedWidthUnsignedInt: Zeroize + Clone + Copy`, so every construction site already satisfies it.

`params` (public modulus + Montgomery constants) is left untouched.

Test mirrors modmath's own `assert_zeroize_on_drop` pattern.

## Summary by Sourcery

Ensure RSA modular math form values are automatically wiped on drop to avoid lingering secret-derived Montgomery state.

Enhancements:
- Tighten ModMathForm generic bound to require Zeroize so it can be safely zeroized on drop.
- Implement Drop and ZeroizeOnDrop for ModMathForm to automatically clear secret Montgomery state while leaving public parameters intact.

Tests:
- Add tests asserting ModMathForm implements ZeroizeOnDrop for both non-constant-time and constant-time small integer types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure memory handling: sensitive cryptographic data is now explicitly cleared from memory when no longer needed.
  * Added compile-time safeguards to ensure the automatic clearing behavior applies across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->