### PR TITLE
Pre-clean: re-gate alloc-only tests off private-key

### DIFF
--- a/src/algorithms/pad.rs
+++ b/src/algorithms/pad.rs
@@ -12,7 +12,7 @@ use core::borrow::Borrow;
 
 /// Returns a new vector of the given length, with 0s left padded.
 #[cfg(test)]
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 fn left_pad(input: &[u8], padded_len: usize) -> Result<Vec<u8>> {
     let mut out = vec![0u8; padded_len];
@@ -91,7 +91,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
     #[test]

--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -247,7 +247,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
     use rand::rngs::ChaCha8Rng;


### PR DESCRIPTION
## Summary

Three test blocks were gated as \`cfg(feature = \"private-key\")\` but their bodies only use \`Vec\`/\`vec![]\` and have nothing to do with private-key concepts. They only happened to align because today's default build path pulls in both via \`encoding → private-key → alloc\`.

Re-gate them to the actual requirement (\`alloc\`).

## Changes

- \`src/algorithms/pad.rs\`: \`fn left_pad\` helper + its \`mod tests\` — \`private-key\` → \`alloc\`
- \`src/algorithms/pkcs1v15.rs\`: \`mod tests\` (\`test_non_zero_bytes\`, \`test_encrypt_tiny_no_crash\`) — \`private-key\` → \`alloc\`

Net: +3/−3 across two files. Cleanup only, no behavior change for any existing build configuration.

Surveyed all 14 files with private-key gates; no other mis-gates of this shape were found.

## Verification

- All standard gates green: default check, \`--no-default-features --features modmath\`, bare \`--no-default-features\`, lib tests (76/76), clippy.
- Confirmed re-gated tests now run under \`cargo test --no-default-features --features alloc\` alone (3 tests passing in that config — previously locked behind \`private-key\`).

## Context

First commit toward the incremental \`wip-private-key\` port story — clearing genuine mis-labels before any real porting work begins.

## Summary by Sourcery

Retarget test-only code that depends on heap allocation to use the alloc feature gate instead of the private-key feature gate.

Enhancements:
- Align feature gating of pad and PKCS#1 v1.5 helper/test modules with their actual alloc-only dependency surface.

Tests:
- Ensure pad and PKCS#1 v1.5 tests run under configurations that enable alloc without requiring the private-key feature.