### PR TITLE
Introduce wip-private-key feature + extract rsa_private_op

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,12 @@ alloc = ["dep:crypto-bigint", "crypto-bigint/alloc", "pkcs8/alloc", "spki/alloc"
 private-key = ["alloc", "dep:crypto-primes"]
 modmath = ["dep:modmath", "dep:fixed-bigint"]
 
+# In-progress: gate for individual private-key functions that have been
+# generalized to work on the no_alloc / modmath path. Enabling this alone
+# (without `private-key`) compiles and tests the ported subset; enabling
+# both gives you the full alloc-bound surface plus any newly ported items.
+wip-private-key = []
+
 [package.metadata.docs.rs]
 features = ["std", "serde", "hazmat", "sha2"]
 

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -147,7 +147,7 @@ pub fn rsa_decrypt<R: TryCryptoRng + ?Sized>(
         }
         _ => {
             // c^d (mod n)
-            pow_mod_params(&c, d, n_params)
+            rsa_private_op(&c, d, n_params)
         }
     };
 
@@ -252,6 +252,29 @@ fn unblind(m: &BoxedUint, unblinder: &BoxedUint, n_params: &BoxedMontyParams) ->
     );
 
     m.mul_mod(unblinder, n_params.modulus().as_nz_ref())
+}
+
+/// ⚠️ Performs the raw RSA private-key operation `c^d mod n`.
+///
+/// This is the bare primitive that both signing and unblinded decryption reduce
+/// to. The operation is constant-time in both base and secret exponent when
+/// `M::MontgomeryForm: Pow<M>` resolves to a Ct-personality implementation
+/// (e.g. `modmath::Field<T, Ct>` via the heapless `modmath_support` adapter).
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Raw RSA must be wrapped in a padding/signature scheme (PKCS#1 v1.5, PSS,
+/// OAEP) to be secure. See the [module-level documentation][crate::hazmat]
+/// for more information.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+#[inline]
+pub fn rsa_private_op<T, M>(c: &T, d: &T, n_params: &M) -> T
+where
+    T: UnsignedModularInt,
+    M: ModulusParams<Modulus = T>,
+    M::MontgomeryForm: Pow<M>,
+{
+    pow_mod_params(c, d, n_params)
 }
 
 /// Computes `base.pow_mod(exp, n)` with precomputed `n_params`.

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -480,7 +480,21 @@ impl<T: ModMathIntCt> IntoMontyForm<ModMathParams<T, Ct>> for ModMathForm<T, Ct>
 }
 
 impl<T: ModMathIntCt> ModMathForm<T, Ct> {
-    fn pow_loop(&self, exp_raw: T) -> T {
+    // Secret-exponent ladder. Used by `Pow::pow`, which is the path RSA
+    // signing and unblinded decryption reduce to — the exponent is `d`,
+    // never disclosed in timing. Routes to modmath's `Field<T, Ct>::exp`,
+    // a fixed-iteration Montgomery ladder with branchless per-bit select.
+    fn pow_loop_ct(&self, exp_raw: T) -> T {
+        let field = self.params.field();
+        let base = field.residue_from_mont(unwrap_value(&self.integer_mont));
+        *field.exp(&base, &exp_raw).mont_value()
+    }
+
+    // Public-exponent ladder. Used by `PowBoundedExp::pow_bounded_exp`,
+    // which acknowledges variable-time-in-exponent semantics — the
+    // exponent is `e` (RSA public verify/encrypt), already disclosed.
+    // Routes to modmath's `Field<T, Ct>::exp_public_exp`.
+    fn pow_loop_public_exp(&self, exp_raw: T) -> T {
         let field = self.params.field();
         let base = field.residue_from_mont(unwrap_value(&self.integer_mont));
         *field.exp_public_exp(&base, &exp_raw).mont_value()
@@ -495,7 +509,7 @@ impl<T: ModMathIntCt> ModMathForm<T, Ct> {
 
 impl<T: ModMathIntCt> Pow<ModMathParams<T, Ct>> for ModMathForm<T, Ct> {
     fn pow(&self, exp: &ModMathValue<T>) -> Self {
-        let result_mont = self.pow_loop(unwrap_value(exp));
+        let result_mont = self.pow_loop_ct(unwrap_value(exp));
         Self {
             integer_mont: wrap_value(result_mont),
             params: self.params.clone(),
@@ -505,7 +519,7 @@ impl<T: ModMathIntCt> Pow<ModMathParams<T, Ct>> for ModMathForm<T, Ct> {
 
 impl<T: ModMathIntCt> PowBoundedExp<ModMathParams<T, Ct>> for ModMathForm<T, Ct> {
     fn pow_bounded_exp(&self, exp: &ModMathValue<T>, _exp_bits: u32) -> Self {
-        let result_mont = self.pow_loop(unwrap_value(exp));
+        let result_mont = self.pow_loop_public_exp(unwrap_value(exp));
         Self {
             integer_mont: wrap_value(result_mont),
             params: self.params.clone(),

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -710,3 +710,28 @@ mod tests {
         assert_eq!(modmath_ciphertext, boxed_ciphertext.as_slice());
     }
 }
+
+// Tests for the `rsa_private_op` primitive on the heapless / Ct path.
+// Gated independently of the alloc+private-key block above so the
+// `wip-private-key` feature (which doesn't imply alloc) can compile
+// and run them in no_alloc mode.
+#[cfg(test)]
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+mod private_op_tests {
+    use super::*;
+    use fixed_bigint::{Ct, FixedUInt};
+
+    type SmallUCt = FixedUInt<u8, 64, Ct>;
+
+    #[test]
+    fn rsa_private_op_round_trip_heapless_ct() {
+        // n = 35 = 5 · 7, φ(n) = 24. e = 5, d = 29 (since 5·29 = 145 ≡ 1 mod 24).
+        // m = 2 → c = 2^5 mod 35 = 32 → m_recovered = 32^29 mod 35 = 2.
+        let n_params = ModMathParams::<SmallUCt, Ct>::new(SmallUCt::from(35u8)).unwrap();
+        let c = wrap_value(SmallUCt::from(32u8));
+        let d = wrap_value(SmallUCt::from(29u8));
+        let expected = wrap_value(SmallUCt::from(2u8));
+        let recovered = crate::algorithms::rsa::rsa_private_op(&c, &d, &n_params);
+        assert_eq!(recovered, expected);
+    }
+}


### PR DESCRIPTION
## Summary

First real step in the incremental private-key port to the heapless path.

- Adds a \`wip-private-key\` Cargo feature for opting into ported items without pulling in \`alloc\` (the way \`private-key\` does today).
- Extracts the bare \`c^d mod n\` primitive that both signing and unblinded decryption reduce to into a standalone, generic, gated function \`rsa_private_op<T, M>(c, d, n_params) -> T\`.
- \`rsa_decrypt\`'s raw-exponent arm now delegates to the new function; the CRT arm is unchanged.

End-to-end behavior on the alloc path is identical.

## Test plan

Adds \`modmath_support::private_op_tests::rsa_private_op_round_trip_heapless_ct\` that exercises the primitive through \`ModMathParams<FixedUInt<u8, 64>, Ct>\` — the heapless Ct path — using \`n = 35 = 5·7\`, \`e = 5\`, \`d = 29\`, round-tripping \`m = 2\`.

The test compiles and passes under \`cargo test --no-default-features --features modmath,wip-private-key\` alone, validating that the new feature gate genuinely enables a working subset on the heapless target.

Verified:
- \`cargo check\` (default), \`--no-default-features\`, \`--no-default-features --features modmath\`, \`--no-default-features --features modmath,wip-private-key\` — all green.
- \`cargo test --lib\` — 77/77 passing (was 76, +1 new).
- \`cargo clippy --all -- -D warnings\` — clean.

## Scope

No trait surgery (per plan); just the primitive extraction + first test under the new gate. Net: +55/−1 across three files.

Next ports build on this same pattern — gate on \`any(feature = "private-key", feature = "wip-private-key")\`, generalize one function/site at a time.

## Summary by Sourcery

Introduce a gated RSA private-key primitive usable on both alloc and heapless modmath paths and add tests and feature wiring for its initial heapless use.

New Features:
- Add a `rsa_private_op` primitive that performs the raw RSA private-key operation `c^d mod n` behind the existing and new feature gates.
- Introduce a `wip-private-key` Cargo feature to enable incrementally ported private-key functionality on the no-alloc modmath path.

Build:
- Extend Cargo feature configuration with the `wip-private-key` feature to selectively compile generalized private-key functionality.

Tests:
- Add a heapless constant-time round-trip test for `rsa_private_op` under the new `wip-private-key` and existing `private-key` feature gates.