### PR TITLE
Add rsa_private_op_and_check (verify-after-private-op)

### DIFF
--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -305,7 +305,13 @@ where
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
 {
     let m = rsa_private_op(c, d, n_params);
-    let check = pow_mod_params_vartime_exp_bits(&m, e, e.bits(), n_params);
+    // `m < n` by construction (output of `rsa_private_op` is in `[0, n)` after
+    // Montgomery retrieve), so we route through `from_reduced` to skip the
+    // variable-time reduction `from_value` would perform on BoxedUint —
+    // `from_value -> rem_vartime` would otherwise leak `m` via timing.
+    let m_sized = m.clone().resize_unchecked(n_params.bits_precision());
+    let m_mont = M::MontgomeryForm::from_reduced(m_sized, n_params);
+    let check = m_mont.pow_bounded_exp(e, e.bits()).retrieve();
     if *c != check {
         return Err(Error::Internal);
     }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -277,6 +277,41 @@ where
     pow_mod_params(c, d, n_params)
 }
 
+/// ⚠️ Performs `rsa_private_op` and verifies the result by re-encrypting
+/// and comparing against the input. This is the integrity check that
+/// PKCS#1 v1.5 / PSS signing reduce to (mirroring the upstream
+/// `rsa_decrypt_and_check` for the raw-exponent path).
+///
+/// Returns the recovered message `m = c^d mod n` only if `m^e mod n == c`,
+/// otherwise [`Error::Internal`]. Defends against transient compute errors
+/// that would otherwise emit a malformed signature (notably the class of
+/// fault attacks that try to leak `p`/`q` from a corrupted CRT step;
+/// today's heapless raw-exponent path doesn't take that branch but the
+/// check shape stays consistent with the upstream invariant).
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Raw RSA must be wrapped in a padding/signature scheme (PKCS#1 v1.5, PSS,
+/// OAEP) to be secure. See the [module-level documentation][crate::hazmat]
+/// for more information.
+// Consumer (the heapless `pkcs1v15` / `pss` sign port) lands in a later PR.
+#[allow(dead_code)]
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+#[inline]
+pub fn rsa_private_op_and_check<T, M>(c: &T, d: &T, e: &T, n_params: &M) -> Result<T>
+where
+    T: UnsignedModularInt,
+    M: ModulusParams<Modulus = T>,
+    M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
+{
+    let m = rsa_private_op(c, d, n_params);
+    let check = pow_mod_params_vartime_exp_bits(&m, e, e.bits(), n_params);
+    if *c != check {
+        return Err(Error::Internal);
+    }
+    Ok(m)
+}
+
 /// Computes `base.pow_mod(exp, n)` with precomputed `n_params`.
 fn pow_mod_params<T, M>(base: &T, exp: &T, n_params: &M) -> T
 where

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -773,8 +773,7 @@ mod private_op_tests {
         let c = wrap_value(SmallUCt::from(32u8));
         let bad_d = wrap_value(SmallUCt::from(11u8));
         let e = wrap_value(SmallUCt::from(5u8));
-        let result =
-            crate::algorithms::rsa::rsa_private_op_and_check(&c, &bad_d, &e, &n_params);
+        let result = crate::algorithms::rsa::rsa_private_op_and_check(&c, &bad_d, &e, &n_params);
         assert!(result.is_err());
     }
 }

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -737,15 +737,44 @@ mod private_op_tests {
 
     type SmallUCt = FixedUInt<u8, 64, Ct>;
 
+    // n = 35 = 5 · 7, φ(n) = 24. e = 5, d = 29 (since 5·29 = 145 ≡ 1 mod 24).
+    // m = 2 → c = 2^5 mod 35 = 32 → m_recovered = 32^29 mod 35 = 2.
+    fn toy_params() -> ModMathParams<SmallUCt, Ct> {
+        ModMathParams::<SmallUCt, Ct>::new(SmallUCt::from(35u8)).unwrap()
+    }
+
     #[test]
     fn rsa_private_op_round_trip_heapless_ct() {
-        // n = 35 = 5 · 7, φ(n) = 24. e = 5, d = 29 (since 5·29 = 145 ≡ 1 mod 24).
-        // m = 2 → c = 2^5 mod 35 = 32 → m_recovered = 32^29 mod 35 = 2.
-        let n_params = ModMathParams::<SmallUCt, Ct>::new(SmallUCt::from(35u8)).unwrap();
+        let n_params = toy_params();
         let c = wrap_value(SmallUCt::from(32u8));
         let d = wrap_value(SmallUCt::from(29u8));
         let expected = wrap_value(SmallUCt::from(2u8));
         let recovered = crate::algorithms::rsa::rsa_private_op(&c, &d, &n_params);
         assert_eq!(recovered, expected);
+    }
+
+    #[test]
+    fn rsa_private_op_and_check_round_trip_heapless_ct() {
+        let n_params = toy_params();
+        let c = wrap_value(SmallUCt::from(32u8));
+        let d = wrap_value(SmallUCt::from(29u8));
+        let e = wrap_value(SmallUCt::from(5u8));
+        let expected = wrap_value(SmallUCt::from(2u8));
+        let recovered =
+            crate::algorithms::rsa::rsa_private_op_and_check(&c, &d, &e, &n_params).unwrap();
+        assert_eq!(recovered, expected);
+    }
+
+    #[test]
+    fn rsa_private_op_and_check_rejects_wrong_exponent() {
+        // Same modulus + e, but a wrong `d` (11 instead of 29). The recovered
+        // `m` won't re-encrypt back to `c`, so the integrity check should fail.
+        let n_params = toy_params();
+        let c = wrap_value(SmallUCt::from(32u8));
+        let bad_d = wrap_value(SmallUCt::from(11u8));
+        let e = wrap_value(SmallUCt::from(5u8));
+        let result =
+            crate::algorithms::rsa::rsa_private_op_and_check(&c, &bad_d, &e, &n_params);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

Next step in the inside-out private-key port. Builds the heapless equivalent of upstream's \`rsa_decrypt_and_check\`: run the private op, then re-encrypt the result with \`e\` and reject if it doesn't round-trip back to the input ciphertext.

This is the function PKCS#1 v1.5 / PSS signing reduce to. The check defends against transient compute errors that would otherwise emit a malformed signature (and, on the future CRT-aware path, fault attacks targeting the CRT step — today's heapless raw-exponent path doesn't take that branch but the shape stays consistent).

## Shape

\`\`\`rust
#[cfg(any(feature = \"private-key\", feature = \"wip-private-key\"))]
pub fn rsa_private_op_and_check<T, M>(c: &T, d: &T, e: &T, n_params: &M) -> Result<T>
where T: UnsignedModularInt, M: ModulusParams<Modulus = T>, M::MontgomeryForm: Pow<M> + PowBoundedExp<M>
\`\`\`

Same gating pattern as \`rsa_private_op\`. Additional \`PowBoundedExp<M>\` bound for the public-exponent re-encrypt.

## Test plan

Two new tests in \`modmath_support::private_op_tests\` exercising both branches:
- \`rsa_private_op_and_check_round_trip_heapless_ct\` — passes with the correct \`(n, e, d)\` triple.
- \`rsa_private_op_and_check_rejects_wrong_exponent\` — returns \`Err(Error::Internal)\` when called with a wrong \`d\`.

Factored the \`n_params\` setup into a \`toy_params()\` helper since three tests now share it.

Verified:
- \`cargo check\` (default), \`--no-default-features\`, \`--no-default-features --features modmath\`, \`--no-default-features --features modmath,wip-private-key\` — all green.
- \`cargo test --lib\` — 79/79 passing (was 77, +2 new).
- \`cargo clippy --all -- -D warnings\` — clean.

## Scope

\`#[allow(dead_code)]\` on the function for now — the real consumer (heapless \`pkcs1v15\` / \`pss\` sign port) lands in a later PR. Removed once that wires through.

Net: +67/−3 across two files. No trait surgery; same pattern as the previous port.

## Summary by Sourcery

Introduce an RSA private operation helper that re-encrypts and checks the ciphertext before returning, alongside supporting tests.

New Features:
- Add rsa_private_op_and_check helper that performs the private exponentiation and verifies correctness by re-applying the public exponent.

Enhancements:
- Document the hazard and integrity-check semantics for the new RSA helper in the hazmat RSA module.
- Factor shared RSA test modulus setup into a reusable toy_params() helper for small heapless test cases.

Tests:
- Add a round-trip test validating rsa_private_op_and_check with matching key parameters.
- Add a negative test ensuring rsa_private_op_and_check rejects when the private exponent is incorrect.