### PR TITLE
Add pkcs1v15::sign_into (heapless RSASSA-PKCS1-V1_5-SIGN)

### DIFF
--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -235,6 +235,19 @@ where
     M: ModulusParams<Modulus = T>,
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
 {
+    // `k` must match the modulus width, otherwise we'd produce a signature
+    // that round-trips against a *different* modulus interpretation than
+    // the one the verifier sees. Same shape as upstream `rsa_decrypt`'s
+    // `c.bits_precision() == n.bits_precision()` check.
+    if k != n_params.bits_precision() as usize / 8 {
+        return Err(Error::InvalidArguments);
+    }
+    // Fail fast on a too-small `sig_storage` rather than letting
+    // `uint_to_be_pad_into` surface `OutputBufferTooSmall` after the
+    // exponentiation work is already done.
+    if sig_storage.len() < k {
+        return Err(Error::OutputBufferTooSmall);
+    }
     let em_slice = pkcs1v15_sign_pad_into(prefix, hashed, k, em_storage)?;
     let em = T::try_from_be_bytes_vartime(em_slice)?;
     let s = crate::algorithms::rsa::rsa_private_op_and_check(&em, d, e, n_params)?;

--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -15,6 +15,11 @@ use rand_core::TryCryptoRng;
 use zeroize::Zeroizing;
 
 use crate::errors::{Error, Result};
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+use crate::traits::{
+    modular::{ModulusParams, Pow, PowBoundedExp},
+    UnsignedModularInt,
+};
 
 /// Fills the provided slice with random values, which are guaranteed
 /// to not be zero.
@@ -179,6 +184,61 @@ pub fn pkcs1v15_sign_pad_into<'a>(
     em[k - hash_len..k].copy_from_slice(hashed);
 
     Ok(em)
+}
+
+/// ⚠️ PKCS#1 v1.5 sign — heapless-compatible, generic over the integer backend.
+///
+/// Composes the four byte/integer steps of `RSASSA-PKCS1-V1_5-SIGN`:
+///
+/// 1. Build the padded encoding
+///    `EM = 0x00 || 0x01 || PS || 0x00 || prefix || hashed` in
+///    caller-provided `em_storage`.
+/// 2. Convert the EM bytes to integer `T` via
+///    [`UnsignedModularInt::try_from_be_bytes_vartime`].
+/// 3. Compute `s = EM^d mod n` via
+///    [`crate::algorithms::rsa::rsa_private_op_and_check`] — CT in the secret
+///    exponent on the Ct-personality heapless path, with a verify-after-sign
+///    integrity check on every backend.
+/// 4. Serialize `s` to bytes, left-padded with zeros to length `k`, into
+///    caller-provided `sig_storage`.
+///
+/// `k` is the byte length of the modulus `n` and determines both the EM
+/// and signature lengths. Both scratch buffers must be at least `k` bytes.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// This is the raw PKCS#1 v1.5 sign primitive over a precomputed modulus
+/// context. Higher-level callers should hash the input message themselves
+/// and prepend the appropriate digest-algorithm DigestInfo prefix.
+///
+/// TODO: switch the final serialization step to `uint_to_zeroizing_be_pad_into`
+/// once fixed-bigint provides `Zeroize` for `BytesHolder`. The intermediate
+/// `T::Bytes` produced by `s.to_be_bytes()` carries the just-signed value
+/// briefly on the stack; today it's a soft-leak window, the future zeroizing
+/// path closes it.
+// Consumer (the heapless `SigningKey<D>` wrapper) lands in a later PR.
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)] // Composing four byte/integer steps; splitting helps nothing.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub fn sign_into<'sig, T, M>(
+    n_params: &M,
+    d: &T,
+    e: &T,
+    prefix: &[u8],
+    hashed: &[u8],
+    k: usize,
+    em_storage: &mut [u8],
+    sig_storage: &'sig mut [u8],
+) -> Result<&'sig [u8]>
+where
+    T: UnsignedModularInt,
+    M: ModulusParams<Modulus = T>,
+    M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
+{
+    let em_slice = pkcs1v15_sign_pad_into(prefix, hashed, k, em_storage)?;
+    let em = T::try_from_be_bytes_vartime(em_slice)?;
+    let s = crate::algorithms::rsa::rsa_private_op_and_check(&em, d, e, n_params)?;
+    crate::algorithms::pad::uint_to_be_pad_into(s, k, sig_storage)
 }
 
 #[inline]

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -776,4 +776,88 @@ mod private_op_tests {
         let result = crate::algorithms::rsa::rsa_private_op_and_check(&c, &bad_d, &e, &n_params);
         assert!(result.is_err());
     }
+
+    // 2048-bit RSA keypair fixture — same `(n, e=65537, d)` used in
+    // `algorithms::rsa::tests::recover_primes_works`. Pulled in here so the
+    // heapless wip-private-key test path can roundtrip-sign without
+    // requiring `alloc`. `e` is rendered as 3-byte BE (`0x010001`) and
+    // resized into `U2048` at test time.
+    const N_2048: [u8; 256] = hex_literal::hex!(
+        "d397b84d98a4c26138ed1b695a8106ead91d553bf06041b62d3fdc50a041e222
+         b8f4529689c1b82c5e71554f5dd69fa2f4b6158cf0dbeb57811a0fc327e1f28e
+         74fe74d3bc166c1eabdc1b8b57b934ca8be5b00b4f29975bcc99acaf415b59bb
+         28a6782bb41a2c3c2976b3c18dbadef62f00c6bb226640095096c0cc60d22fe7
+         ef987d75c6a81b10d96bf292028af110dc7cc1bbc43d22adab379a0cd5d8078c
+         c780ff5cd6209dea34c922cf784f7717e428d75b5aec8ff30e5f0141510766e2
+         e0ab8d473c84e8710b2b98227c3db095337ad3452f19e2b9bfbccdd8148abf67
+         76fa552775e6e75956e45229ae5a9c46949bab1e622f0e48f56524a84ed3483b"
+    );
+    const D_2048: [u8; 256] = hex_literal::hex!(
+        "c4e70c689162c94c660828191b52b4d8392115df486a9adbe831e458d7395832
+         0dc1b755456e93701e9702d76fb0b92f90e01d1fe248153281fe79aa9763a92f
+         ae69d8d7ecd144de29fa135bd14f9573e349e45031e3b76982f583003826c552
+         e89a397c1a06bd2163488630d92e8c2bb643d7abef700da95d685c941489a46f
+         54b5316f62b5d2c3a7f1bbd134cb37353a44683fdc9d95d36458de22f6c44057
+         fe74a0a436c4308f73f4da42f35c47ac16a7138d483afc91e41dc3a1127382e0
+         c0f5119b0221b4fc639d6b9c38177a6de9b526ebd88c38d7982c07f98a0efd87
+         7d508aae275b946915c02e2e1106d175d74ec6777f5e80d12c053d9c7be1e341"
+    );
+
+    #[test]
+    fn pkcs1v15_sign_into_round_trip_2048_sha1() {
+        use crate::algorithms::pkcs1v15::{
+            pkcs1v15_generate_prefix_into, pkcs1v15_sign_pad_into, sign_into,
+        };
+        use crate::traits::PublicKeyParts;
+        use sha1::Sha1;
+
+        type U2048 = FixedUInt<u8, 256, Ct>;
+        const K: usize = 256;
+
+        let key = public_key_ct_from_be_bytes::<U2048>(&N_2048, 65537).unwrap();
+        let d_int = <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap();
+        let d = wrap_value(d_int);
+        let e_int =
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&[0x01, 0x00, 0x01])
+                .unwrap();
+        let e = wrap_value(e_int);
+
+        let digest = [0xAAu8; 20];
+        let mut prefix_storage = [0u8; 32];
+        let prefix = pkcs1v15_generate_prefix_into::<Sha1>(&mut prefix_storage).unwrap();
+
+        let mut em_storage = [0u8; K];
+        let mut sig_storage = [0u8; K];
+        let sig = sign_into(
+            key.n_params(),
+            &d,
+            &e,
+            prefix,
+            &digest,
+            K,
+            &mut em_storage,
+            &mut sig_storage,
+        )
+        .unwrap();
+        assert_eq!(sig.len(), K);
+
+        // Roundtrip via public op: `sig^e mod n` must recover the padded EM
+        // that `pkcs1v15_sign_pad_into` produces for the same (prefix, digest).
+        let recovered = public_key_op_ct(&key, sig).unwrap();
+        let mut expected_em_storage = [0u8; K];
+        let expected_em =
+            pkcs1v15_sign_pad_into(prefix, &digest, K, &mut expected_em_storage).unwrap();
+        assert_eq!(recovered.as_ref(), expected_em);
+    }
+
+    // Local alias for `rsa_public_op_ct` — keeps the test's call-site short.
+    fn public_key_op_ct<T>(
+        key: &crate::key::GenericRsaPublicKey<ModMathValue<T>, ModMathParams<T, Ct>>,
+        input: &[u8],
+    ) -> Result<<ModMathValue<T> as UnsignedModularInt>::Bytes>
+    where
+        T: ModMathIntCt,
+    {
+        crate::modmath_support::rsa_public_op_ct(key, input)
+    }
 }


### PR DESCRIPTION
## Summary

Next inside-out step in the wip-private-key port. Composes the four byte/integer atoms of RSASSA-PKCS1-V1_5-SIGN into a single generic function that lives on the heapless path.

Steps:
1. \`pkcs1v15_sign_pad_into(prefix, hashed, k, em_storage)\` — build EM into a caller-supplied slice (already pub).
2. \`T::try_from_be_bytes_vartime(em_slice)\` — bytes → integer.
3. \`rsa_private_op_and_check(&em, d, e, n_params)\` — CT private op with verify-after-sign integrity check (landed PR #20).
4. \`uint_to_be_pad_into(s, k, sig_storage)\` — integer → bytes.

All four building blocks already existed; this wires them together with the right trait bounds.

## Test plan

End-to-end roundtrip with a 2048-bit \`(n, e=65537, d)\` keypair fixture (same one used by \`algorithms::rsa::tests::recover_primes_works\`):
- \`FixedUInt<u8, 256, Ct>\` storage, SHA-1 DigestInfo prefix, fixed test digest.
- Sign produces a 256-byte signature.
- \`sig^e mod n\` via \`rsa_public_op_ct\` recovers exactly the EM that \`pkcs1v15_sign_pad_into\` produces for the same (prefix, digest).

Verified:
- \`cargo test --lib\` — 80/80 passing (was 79, +1 new).
- \`cargo test --lib --no-default-features --features modmath,wip-private-key\` — 4 tests pass (the new sign roundtrip + the three from PRs #19/#20).
- \`cargo check\` (default), \`--no-default-features\`, \`--no-default-features --features modmath\` — all green.
- \`cargo clippy --all -- -D warnings\` — clean.
- \`cargo fmt --check\` — clean.

## Scope

\`#[allow(dead_code)]\` on the function — the heapless \`SigningKey<D>\` wrapper that will consume it lands in a later PR.

Step 4 uses \`uint_to_be_pad_into\` (non-zeroizing) for now because fixed-bigint 0.3.x's \`BytesHolder\` doesn't impl \`Zeroize\`. TODO in the docstring to switch to \`uint_to_zeroizing_be_pad_into\` once upstream lands — the intermediate \`T::Bytes\` carries the just-signed value briefly on the stack; today's a soft-leak window the future zeroizing path closes.

Net: +144 lines across two files. No trait surgery; pure composition.

## Summary by Sourcery

Introduce a heapless, integer-backend-generic PKCS#1 v1.5 signing helper and validate it with a 2048-bit RSA round-trip test.

New Features:
- Add a generic `pkcs1v15::sign_into` helper that performs RSASSA-PKCS1-v1_5 signing into caller-provided buffers without requiring heap allocation.

Enhancements:
- Document the signing flow, modulus-size assumptions, and future zeroizing serialization improvement for the new PKCS#1 v1.5 signing helper.

Tests:
- Add a 2048-bit SHA-1 PKCS#1 v1.5 signing round-trip test using a fixed RSA keypair to verify the new helper against the public operation.