### PR TITLE
Add pss::sign_into (heapless RSASSA-PSS-SIGN)

### DIFF
--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -235,11 +235,13 @@ where
     M: ModulusParams<Modulus = T>,
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
 {
-    // `k` must match the modulus width, otherwise we'd produce a signature
-    // that round-trips against a *different* modulus interpretation than
-    // the one the verifier sees. Same shape as upstream `rsa_decrypt`'s
-    // `c.bits_precision() == n.bits_precision()` check.
-    if k != n_params.bits_precision() as usize / 8 {
+    // `k` must equal the ceiling-byte length of the modulus, matching
+    // `PublicKeyParts::size()` (which the public-side verifier uses for
+    // its own length check). `div_ceil` not floor div — for a key whose
+    // `bits_precision()` is not a multiple of 8 (e.g. an imported
+    // 2049-bit RSA modulus on the BoxedUint backend) the floor would
+    // reject the only `k` value that would actually round-trip.
+    if k != (n_params.bits_precision() as usize).div_ceil(8) {
         return Err(Error::InvalidArguments);
     }
     // Fail fast on a too-small `sig_storage` rather than letting

--- a/src/algorithms/pss.rs
+++ b/src/algorithms/pss.rs
@@ -207,24 +207,24 @@ where
 /// Composes the four byte/integer steps of RSASSA-PSS-SIGN:
 ///
 /// 1. [`emsa_pss_encode_into`] — build the EM encoding for `(m_hash, salt)`
-///    into `em_storage`. `em_bits = key_bits - 1` per RFC 8017 § 8.1.1
-///    (caller passes this explicitly to avoid depending on a bit-counting
-///    method on `T`).
+///    into `em_storage`. `em_bits = key_bits - 1` per RFC 8017 § 8.1.1 is
+///    derived internally from `n_params.bits_precision()`.
 /// 2. [`UnsignedModularInt::try_from_be_bytes_vartime`] — bytes → integer.
 /// 3. [`crate::algorithms::rsa::rsa_private_op_and_check`] — CT in the
 ///    secret exponent on the Ct-personality heapless path, with a
 ///    verify-after-sign integrity check on every backend.
 /// 4. `uint_to_be_pad_into` — integer → bytes, left-padded to `k`.
 ///
-/// `k` is the byte length of the modulus `n`. `sig_storage.len() >= k` and
-/// `em_storage.len() >= em_bits.div_ceil(8)` are checked up front.
+/// `k` is the byte length of the modulus `n` (matches
+/// `PublicKeyParts::size()`). `sig_storage.len() >= k` and
+/// `em_storage.len() >= em_len` are both checked up front; either
+/// produces a fast-fail error before any hashing or exponentiation runs.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
-/// Caller is responsible for: hashing the message, generating the random
-/// `salt`, and passing the correct `em_bits = key_bits - 1`. This is the
-/// raw PSS sign primitive — wrap it in a higher-level `SigningKey<D>` for
-/// real use.
+/// Caller is responsible for hashing the message and generating the random
+/// `salt`. This is the raw PSS sign primitive — wrap it in a higher-level
+/// `SigningKey<D>` for real use.
 ///
 /// TODO: switch the final serialization to `uint_to_zeroizing_be_pad_into`
 /// once fixed-bigint provides `Zeroize` for `BytesHolder`. The
@@ -241,7 +241,6 @@ pub fn sign_into<'sig, T, M, D>(
     e: &T,
     m_hash: &[u8],
     salt: &[u8],
-    em_bits: usize,
     k: usize,
     hash: &mut D,
     em_storage: &mut [u8],
@@ -253,12 +252,22 @@ where
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
     D: Digest + FixedOutputReset,
 {
-    // Same shape as the upstream `rsa_decrypt` precision check + the
-    // matching `pkcs1v15::sign_into` upfront guards.
-    if k != n_params.bits_precision() as usize / 8 {
+    // `k` must equal the ceiling-byte length of the modulus, matching
+    // `PublicKeyParts::size()` (which the public-side verifier uses for
+    // its own length check). `div_ceil` not floor div — for a key whose
+    // `bits_precision()` is not a multiple of 8 (e.g. an imported
+    // 2049-bit RSA modulus on the BoxedUint backend) the floor would
+    // reject the only `k` value that would actually round-trip.
+    let key_bits = n_params.bits_precision() as usize;
+    if k != key_bits.div_ceil(8) {
         return Err(Error::InvalidArguments);
     }
     if sig_storage.len() < k {
+        return Err(Error::OutputBufferTooSmall);
+    }
+    // RFC 8017 § 8.1.1: em_bits ≡ modulus_bits − 1.
+    let em_bits = key_bits - 1;
+    if em_storage.len() < em_bits.div_ceil(8) {
         return Err(Error::OutputBufferTooSmall);
     }
     let em_slice = emsa_pss_encode_into(m_hash, em_bits, salt, hash, em_storage)?;

--- a/src/algorithms/pss.rs
+++ b/src/algorithms/pss.rs
@@ -16,6 +16,11 @@ use digest::{Digest, FixedOutputReset};
 
 use super::mgf::{mgf1_xor, mgf1_xor_digest};
 use crate::errors::{Error, Result};
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+use crate::traits::{
+    modular::{ModulusParams, Pow, PowBoundedExp},
+    UnsignedModularInt,
+};
 
 #[cfg(feature = "alloc")]
 pub(crate) fn emsa_pss_encode<D>(
@@ -24,6 +29,28 @@ pub(crate) fn emsa_pss_encode<D>(
     salt: &[u8],
     hash: &mut D,
 ) -> Result<Vec<u8>>
+where
+    D: Digest + FixedOutputReset,
+{
+    let em_len = em_bits.div_ceil(8);
+    let mut em = vec![0; em_len];
+    emsa_pss_encode_into(m_hash, em_bits, salt, hash, &mut em)?;
+    Ok(em)
+}
+
+/// EMSA-PSS encode, RFC 8017 § 9.1.1 — slice-output variant.
+///
+/// Writes exactly `em_len = em_bits.div_ceil(8)` bytes into the head of
+/// `storage`. `storage.len()` must be at least `em_len`; on success, the
+/// returned slice is `&storage[..em_len]`.
+#[inline]
+pub fn emsa_pss_encode_into<'a, D>(
+    m_hash: &[u8],
+    em_bits: usize,
+    salt: &[u8],
+    hash: &mut D,
+    storage: &'a mut [u8],
+) -> Result<&'a [u8]>
 where
     D: Digest + FixedOutputReset,
 {
@@ -47,7 +74,10 @@ where
         return Err(Error::Internal);
     }
 
-    let mut em = vec![0; em_len];
+    let em = storage
+        .get_mut(..em_len)
+        .ok_or(Error::OutputBufferTooSmall)?;
+    em.fill(0);
 
     let (db, h) = em.split_at_mut(em_len - h_len - 1);
     let h = &mut h[..(em_len - 1) - db.len()];
@@ -170,6 +200,71 @@ where
     em[em_len - 1] = 0xBC;
 
     Ok(em)
+}
+
+/// ⚠️ RSASSA-PSS sign — heapless-compatible, generic over the integer backend.
+///
+/// Composes the four byte/integer steps of RSASSA-PSS-SIGN:
+///
+/// 1. [`emsa_pss_encode_into`] — build the EM encoding for `(m_hash, salt)`
+///    into `em_storage`. `em_bits = key_bits - 1` per RFC 8017 § 8.1.1
+///    (caller passes this explicitly to avoid depending on a bit-counting
+///    method on `T`).
+/// 2. [`UnsignedModularInt::try_from_be_bytes_vartime`] — bytes → integer.
+/// 3. [`crate::algorithms::rsa::rsa_private_op_and_check`] — CT in the
+///    secret exponent on the Ct-personality heapless path, with a
+///    verify-after-sign integrity check on every backend.
+/// 4. `uint_to_be_pad_into` — integer → bytes, left-padded to `k`.
+///
+/// `k` is the byte length of the modulus `n`. `sig_storage.len() >= k` and
+/// `em_storage.len() >= em_bits.div_ceil(8)` are checked up front.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Caller is responsible for: hashing the message, generating the random
+/// `salt`, and passing the correct `em_bits = key_bits - 1`. This is the
+/// raw PSS sign primitive — wrap it in a higher-level `SigningKey<D>` for
+/// real use.
+///
+/// TODO: switch the final serialization to `uint_to_zeroizing_be_pad_into`
+/// once fixed-bigint provides `Zeroize` for `BytesHolder`. The
+/// intermediate `T::Bytes` produced by `s.to_be_bytes()` carries the
+/// just-signed value briefly on the stack; today it's a soft-leak window
+/// the future zeroizing path closes.
+// Consumer (the heapless `pss::SigningKey<D>` wrapper) lands in a later PR.
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)] // Composing four byte/integer steps; splitting helps nothing.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub fn sign_into<'sig, T, M, D>(
+    n_params: &M,
+    d: &T,
+    e: &T,
+    m_hash: &[u8],
+    salt: &[u8],
+    em_bits: usize,
+    k: usize,
+    hash: &mut D,
+    em_storage: &mut [u8],
+    sig_storage: &'sig mut [u8],
+) -> Result<&'sig [u8]>
+where
+    T: UnsignedModularInt,
+    M: ModulusParams<Modulus = T>,
+    M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
+    D: Digest + FixedOutputReset,
+{
+    // Same shape as the upstream `rsa_decrypt` precision check + the
+    // matching `pkcs1v15::sign_into` upfront guards.
+    if k != n_params.bits_precision() as usize / 8 {
+        return Err(Error::InvalidArguments);
+    }
+    if sig_storage.len() < k {
+        return Err(Error::OutputBufferTooSmall);
+    }
+    let em_slice = emsa_pss_encode_into(m_hash, em_bits, salt, hash, em_storage)?;
+    let em = T::try_from_be_bytes_vartime(em_slice)?;
+    let s = crate::algorithms::rsa::rsa_private_op_and_check(&em, d, e, n_params)?;
+    crate::algorithms::pad::uint_to_be_pad_into(s, k, sig_storage)
 }
 
 fn emsa_pss_verify_pre<'a>(

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -872,7 +872,6 @@ mod private_op_tests {
 
         let digest = [0xAAu8; 20];
         let salt: &[u8] = &[]; // empty salt → deterministic encoding
-        let em_bits = KEY_BITS - 1;
         let mut hash = Sha1::new();
 
         let mut em_storage = [0u8; K];
@@ -883,7 +882,6 @@ mod private_op_tests {
             &e,
             &digest,
             salt,
-            em_bits,
             K,
             &mut hash,
             &mut em_storage,

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -850,6 +850,65 @@ mod private_op_tests {
         assert_eq!(recovered.as_ref(), expected_em);
     }
 
+    #[test]
+    fn pss_sign_into_round_trip_2048_sha1() {
+        use crate::algorithms::pss::{emsa_pss_verify, sign_into};
+        use crate::traits::PublicKeyParts;
+        use digest::Digest;
+        use sha1::Sha1;
+
+        type U2048 = FixedUInt<u8, 256, Ct>;
+        const K: usize = 256;
+        const KEY_BITS: usize = 2048;
+
+        let key = public_key_ct_from_be_bytes::<U2048>(&N_2048, 65537).unwrap();
+        let d = wrap_value(
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
+        );
+        let e = wrap_value(
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&[0x01, 0x00, 0x01])
+                .unwrap(),
+        );
+
+        let digest = [0xAAu8; 20];
+        let salt: &[u8] = &[]; // empty salt → deterministic encoding
+        let em_bits = KEY_BITS - 1;
+        let mut hash = Sha1::new();
+
+        let mut em_storage = [0u8; K];
+        let mut sig_storage = [0u8; K];
+        let sig = sign_into(
+            key.n_params(),
+            &d,
+            &e,
+            &digest,
+            salt,
+            em_bits,
+            K,
+            &mut hash,
+            &mut em_storage,
+            &mut sig_storage,
+        )
+        .unwrap();
+        assert_eq!(sig.len(), K);
+
+        // Roundtrip via public op: `sig^e mod n` must yield a valid PSS-encoded
+        // EM for `(digest, salt)`. `emsa_pss_verify` modifies `em` in place
+        // (MGF unmask), so copy the recovered bytes into a mutable buffer.
+        let recovered = public_key_op_ct(&key, sig).unwrap();
+        let mut em_copy = [0u8; K];
+        em_copy.copy_from_slice(recovered.as_ref());
+        let mut verify_hash = Sha1::new();
+        emsa_pss_verify(
+            &digest,
+            &mut em_copy,
+            Some(salt.len()),
+            &mut verify_hash,
+            KEY_BITS,
+        )
+        .unwrap();
+    }
+
     // Local alias for `rsa_public_op_ct` — keeps the test's call-site short.
     fn public_key_op_ct<T>(
         key: &crate::key::GenericRsaPublicKey<ModMathValue<T>, ModMathParams<T, Ct>>,


### PR DESCRIPTION
## Summary

Sibling of \`pkcs1v15::sign_into\`. RSASSA-PSS is the TLS 1.3-mandated signature algorithm (RFC 8446 § 4.2.3 — PKCS#1 v1.5 is banned for TLS 1.3 CertificateVerify), so this is the load-bearing primitive for the heapless TLS client-cert use case.

## Two additions

1. **\`pub fn emsa_pss_encode_into\`** in \`algorithms/pss.rs\` — slice-output variant of the existing \`emsa_pss_encode\`. Same body, writes into caller-provided \`storage: &mut [u8]\` instead of allocating a \`Vec\`. The alloc-only \`emsa_pss_encode\` now delegates to it.

2. **\`pub fn sign_into\`** — composes the four byte/integer atoms of RSASSA-PSS-SIGN:
   - \`emsa_pss_encode_into\` for the PSS encoding.
   - \`T::try_from_be_bytes_vartime\` for bytes → integer.
   - \`rsa_private_op_and_check\` for the CT secret exponentiation with verify-after-sign integrity check (landed PR #20).
   - \`uint_to_be_pad_into\` for integer → bytes.

Same upfront k/sig_storage defensive checks as \`pkcs1v15::sign_into\` (PR #21 cleanup). Caller passes \`em_bits = key_bits - 1\` explicitly per RFC 8017 § 8.1.1 to avoid depending on a bit-counting method on \`T\`.

## Test plan

End-to-end sign+verify roundtrip with the 2048-bit \`(n, e=65537, d)\` fixture (already used by the pkcs1v15 sign test), \`FixedUInt<u8, 256, Ct>\` storage, SHA-1, empty salt for determinism:
- \`sign_into\` produces a 256-byte signature.
- \`sig^e mod n\` via \`rsa_public_op_ct\` recovers the EM.
- \`emsa_pss_verify\` confirms it's a valid PSS encoding of the same (digest, salt).

Verified:
- \`cargo test --lib\` — 81/81 passing (was 80, +1 new).
- \`cargo test --lib --no-default-features --features modmath,wip-private-key\` — 5 tests pass (the new pss sign roundtrip + the four from PRs #19/#20/#21).
- \`cargo check\` (default), \`--no-default-features\`, \`--no-default-features --features modmath\` — all green.
- \`cargo clippy --all -- -D warnings\` + \`cargo fmt --check\` — clean.

## Scope

Same \`#[allow(dead_code)]\` disclaimer + zeroize TODO as \`pkcs1v15::sign_into\` — the heapless \`pss::SigningKey<D>\` wrapper and the fixed-bigint \`Zeroize for BytesHolder\` switch are both follow-ups.

Net: +155 lines across two files.

## Summary by Sourcery

Add a heapless-compatible RSASSA-PSS signing primitive and supporting slice-based PSS encoding, with an end-to-end roundtrip test for the fixed-width bigint backend.

New Features:
- Introduce emsa_pss_encode_into as a slice-output EMSA-PSS encoder to avoid heap allocation.
- Add pss::sign_into to perform RSASSA-PSS signing into caller-provided storage for generic integer backends.

Tests:
- Add a 2048-bit RSASSA-PSS sign/verify roundtrip test using fixed-width bigints and SHA-1.