### PR TITLE
Phase 1 trait surgery: GenericPrivateKeyParts + GenericRsaPrivateKey

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -101,9 +101,10 @@ where
 /// Generic RSA private key — heapless-compatible value type.
 ///
 /// Holds the public components plus the secret exponent `d`. Mirrors
-/// [`GenericRsaPublicKey`] in shape; satisfies both [`PublicKeyParts`]
-/// (via delegation to the inner pubkey) and [`GenericPrivateKeyParts`]
-/// at the same `T, M` substitution.
+/// [`GenericRsaPublicKey`] in shape; satisfies both [`PublicKeyParts<T>`]
+/// (via delegation to the inner pubkey) and [`GenericPrivateKeyParts<T>`]
+/// — the Montgomery parameter type `M` comes through `PublicKeyParts`'s
+/// `MontyParams` associated type.
 ///
 /// Deliberately minimal: no `primes`, no `precomputed` CRT values, no
 /// keygen. This is the (n, e, d) private form suitable for the raw
@@ -111,7 +112,7 @@ where
 /// extension trait when the dependency stack provides CT modular
 /// inverse — see the roadmap in `CLAUDE.md`.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -121,6 +122,24 @@ where
     pubkey_components: GenericRsaPublicKey<T, M>,
     /// Private exponent.
     d: T,
+}
+
+// Manual `Debug` impl — never print `d`. Mirrors the redaction in the
+// existing alloc-side `RsaPrivateKey::fmt` so `{:?}` on a key value
+// can't leak private material into logs.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> fmt::Debug for GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+    GenericRsaPublicKey<T, M>: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GenericRsaPrivateKey")
+            .field("pubkey_components", &self.pubkey_components)
+            .field("d", &"...")
+            .finish()
+    }
 }
 
 // Consumer (heapless `pkcs1v15::SigningKey<D>` / `pss::SigningKey<D>`
@@ -171,13 +190,28 @@ where
 }
 
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-impl<T, M> GenericPrivateKeyParts<T, M> for GenericRsaPrivateKey<T, M>
+impl<T, M> GenericPrivateKeyParts<T> for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
     M: ModulusParams<Modulus = T>,
 {
     fn d(&self) -> &T {
         &self.d
+    }
+}
+
+// Canonical `Zeroize` shape: impl on the type, `Drop` delegates so
+// the wipe lives in one place, `ZeroizeOnDrop` is the load-bearing
+// marker callers can rely on. Mirrors the `ModMathForm` pattern from
+// PR #17. The pubkey is public material; only `d` needs wiping.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> Zeroize for GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    fn zeroize(&mut self) {
+        self.d.zeroize();
     }
 }
 
@@ -188,7 +222,7 @@ where
     M: ModulusParams<Modulus = T>,
 {
     fn drop(&mut self) {
-        self.d.zeroize();
+        self.zeroize();
     }
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -34,6 +34,8 @@ use crate::algorithms::rsa::{
 #[cfg(feature = "private-key")]
 use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+use crate::traits::keys::GenericPrivateKeyParts;
 use crate::traits::keys::PublicKeyParts;
 #[cfg(feature = "private-key")]
 use crate::traits::keys::{CrtValue, PrivateKeyParts};
@@ -94,6 +96,108 @@ where
         state.write(self.n.as_ref().to_be_bytes().as_ref());
         state.write(self.e.to_be_bytes().as_ref());
     }
+}
+
+/// Generic RSA private key — heapless-compatible value type.
+///
+/// Holds the public components plus the secret exponent `d`. Mirrors
+/// [`GenericRsaPublicKey`] in shape; satisfies both [`PublicKeyParts`]
+/// (via delegation to the inner pubkey) and [`GenericPrivateKeyParts`]
+/// at the same `T, M` substitution.
+///
+/// Deliberately minimal: no `primes`, no `precomputed` CRT values, no
+/// keygen. This is the (n, e, d) private form suitable for the raw
+/// signing path. CRT support arrives later behind a separate
+/// extension trait when the dependency stack provides CT modular
+/// inverse — see the roadmap in `CLAUDE.md`.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+#[derive(Clone, Debug)]
+pub struct GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    /// Public components of the private key.
+    pubkey_components: GenericRsaPublicKey<T, M>,
+    /// Private exponent.
+    d: T,
+}
+
+// Consumer (heapless `pkcs1v15::SigningKey<D>` / `pss::SigningKey<D>`
+// wrappers) lands in Phase 2.
+#[allow(dead_code)]
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    /// Construct from the components of a precomputed key. Caller is
+    /// responsible for the cryptographic relationship between `n`, `e`,
+    /// and `d` (typically `e * d ≡ 1 mod λ(n)`); no validation is
+    /// performed here.
+    pub fn from_components(pubkey_components: GenericRsaPublicKey<T, M>, d: T) -> Self {
+        Self {
+            pubkey_components,
+            d,
+        }
+    }
+
+    /// Borrow the public-key components.
+    pub fn as_public(&self) -> &GenericRsaPublicKey<T, M> {
+        &self.pubkey_components
+    }
+}
+
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> PublicKeyParts<T> for GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    type MontyParams = M;
+
+    fn n(&self) -> &NonZero<T> {
+        self.pubkey_components.n()
+    }
+
+    fn e(&self) -> &T {
+        self.pubkey_components.e()
+    }
+
+    fn n_params(&self) -> &Self::MontyParams {
+        self.pubkey_components.n_params()
+    }
+}
+
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> GenericPrivateKeyParts<T, M> for GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    fn d(&self) -> &T {
+        &self.d
+    }
+}
+
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> Drop for GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    fn drop(&mut self) {
+        self.d.zeroize();
+    }
+}
+
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> ZeroizeOnDrop for GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
 }
 
 /// Represents a whole RSA key, public and private parts.

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1095,4 +1095,45 @@ mod private_op_tests {
         );
         assert!(matches!(result, Err(Error::InputNotHashed)));
     }
+
+    // ─── Phase 1 trait surgery: GenericPrivateKeyParts smoke tests ──────
+
+    #[test]
+    fn generic_rsa_private_key_satisfies_traits() {
+        // Compile-time assertion: GenericRsaPrivateKey<SmallUCt, ModMathParams<SmallUCt, Ct>>
+        // satisfies both PublicKeyParts and GenericPrivateKeyParts at the
+        // matching (T, M) substitution. The fn-bound dance below is the
+        // standard "type-satisfies-trait" check.
+        use crate::key::GenericRsaPrivateKey;
+        use crate::traits::keys::{GenericPrivateKeyParts, PublicKeyParts};
+        fn assert_pub_parts<K, T>(_: &K)
+        where
+            T: UnsignedModularInt,
+            K: PublicKeyParts<T>,
+        {
+        }
+        fn assert_priv_parts<K, T, M>(_: &K)
+        where
+            T: UnsignedModularInt,
+            M: ModulusParams<Modulus = T>,
+            K: GenericPrivateKeyParts<T, M>,
+        {
+        }
+
+        // Use the existing public-key constructor for the pubkey side,
+        // then attach a dummy d.
+        let public =
+            crate::modmath_support::public_key_ct_from_be_bytes::<SmallUCt>(&[35u8], 5).unwrap();
+        let key = GenericRsaPrivateKey::from_components(public, wrap_value(SmallUCt::from(29u8)));
+
+        assert_pub_parts::<_, ModMathValue<SmallUCt>>(&key);
+        assert_priv_parts::<_, ModMathValue<SmallUCt>, ModMathParams<SmallUCt, Ct>>(&key);
+
+        // Round-trip: accessors return the values we constructed it with.
+        assert_eq!(
+            GenericPrivateKeyParts::d(&key),
+            &wrap_value(SmallUCt::from(29u8))
+        );
+        assert_eq!(key.as_public().e(), &wrap_value(SmallUCt::from(5u8)));
+    }
 }

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1112,11 +1112,10 @@ mod private_op_tests {
             K: PublicKeyParts<T>,
         {
         }
-        fn assert_priv_parts<K, T, M>(_: &K)
+        fn assert_priv_parts<K, T>(_: &K)
         where
             T: UnsignedModularInt,
-            M: ModulusParams<Modulus = T>,
-            K: GenericPrivateKeyParts<T, M>,
+            K: GenericPrivateKeyParts<T>,
         {
         }
 
@@ -1127,7 +1126,7 @@ mod private_op_tests {
         let key = GenericRsaPrivateKey::from_components(public, wrap_value(SmallUCt::from(29u8)));
 
         assert_pub_parts::<_, ModMathValue<SmallUCt>>(&key);
-        assert_priv_parts::<_, ModMathValue<SmallUCt>, ModMathParams<SmallUCt, Ct>>(&key);
+        assert_priv_parts::<_, ModMathValue<SmallUCt>>(&key);
 
         // Round-trip: accessors return the values we constructed it with.
         assert_eq!(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,6 +6,8 @@ pub(crate) mod modular;
 mod padding;
 
 pub use encryption::{Decryptor, EncryptingKeypair, RandomizedDecryptor, RandomizedEncryptor};
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub use keys::GenericPrivateKeyParts;
 #[cfg(not(feature = "private-key"))]
 pub use keys::PublicKeyParts;
 #[cfg(feature = "private-key")]

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -65,24 +65,23 @@ pub trait PublicKeyParts<T: UnsignedModularInt> {
 /// `K: PrivateKeyParts` value also satisfies
 /// `GenericPrivateKeyParts<BoxedUint, BoxedMontyParams>`.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-pub trait GenericPrivateKeyParts<T, M>: PublicKeyParts<T, MontyParams = M>
+pub trait GenericPrivateKeyParts<T>: PublicKeyParts<T>
 where
     T: UnsignedModularInt,
-    M: ModulusParams<Modulus = T>,
 {
     /// Returns the private exponent of the key.
     fn d(&self) -> &T;
 }
 
 /// Bridge: every legacy [`PrivateKeyParts`] impl also satisfies the
-/// generic trait at the concrete `BoxedUint` / `BoxedMontyParams`
-/// substitution. Lets existing alloc-side consumers (and the upstream
+/// generic trait at the concrete `BoxedUint` substitution. Lets
+/// existing alloc-side consumers (and the upstream
 /// `algorithms::rsa::rsa_decrypt[_and_check]` path) be re-bound on
 /// `GenericPrivateKeyParts` incrementally without breaking compilation.
 #[cfg(feature = "private-key")]
-impl<K> GenericPrivateKeyParts<BoxedUint, BoxedMontyParams> for K
+impl<K> GenericPrivateKeyParts<BoxedUint> for K
 where
-    K: PrivateKeyParts + PublicKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
+    K: PrivateKeyParts,
 {
     fn d(&self) -> &BoxedUint {
         PrivateKeyParts::d(self)

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -49,6 +49,46 @@ pub trait PublicKeyParts<T: UnsignedModularInt> {
     }
 }
 
+/// Generic components of an RSA private key — minimal trait for the
+/// heapless / wip-private-key port.
+///
+/// Mirrors [`PublicKeyParts`] in shape: generic over both the integer
+/// type `T` and the Montgomery parameter type `M`, no concrete
+/// dependency on `BoxedUint`/`BoxedMontyParams`. The minimal surface
+/// is `d()` only — CRT accessors (`dp`/`dq`/`qinv`/`p_params`/`q_params`)
+/// are deliberately omitted from this trait; they'll arrive on a
+/// future `GenericCrtPrivateKeyParts` extension trait when CT modular
+/// inverse lands upstream and we can support CRT on the heapless path.
+///
+/// The legacy [`PrivateKeyParts`] (alloc-bound, `BoxedUint`-concrete)
+/// is bridged to this trait via a blanket impl, so any existing
+/// `K: PrivateKeyParts` value also satisfies
+/// `GenericPrivateKeyParts<BoxedUint, BoxedMontyParams>`.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub trait GenericPrivateKeyParts<T, M>: PublicKeyParts<T, MontyParams = M>
+where
+    T: UnsignedModularInt,
+    M: ModulusParams<Modulus = T>,
+{
+    /// Returns the private exponent of the key.
+    fn d(&self) -> &T;
+}
+
+/// Bridge: every legacy [`PrivateKeyParts`] impl also satisfies the
+/// generic trait at the concrete `BoxedUint` / `BoxedMontyParams`
+/// substitution. Lets existing alloc-side consumers (and the upstream
+/// `algorithms::rsa::rsa_decrypt[_and_check]` path) be re-bound on
+/// `GenericPrivateKeyParts` incrementally without breaking compilation.
+#[cfg(feature = "private-key")]
+impl<K> GenericPrivateKeyParts<BoxedUint, BoxedMontyParams> for K
+where
+    K: PrivateKeyParts + PublicKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
+{
+    fn d(&self) -> &BoxedUint {
+        PrivateKeyParts::d(self)
+    }
+}
+
 /// Components of an RSA private key.
 #[cfg(feature = "private-key")]
 pub trait PrivateKeyParts: PublicKeyParts<BoxedUint> {


### PR DESCRIPTION
## Summary

First step of the shadow-trait migration toward heapless \`SigningKey<D>\` wrappers (per the roadmap in CLAUDE.md). Introduces the new generic trait + value type under new names so nothing existing breaks.

## What lands

**\`traits::keys::GenericPrivateKeyParts<T, M>\`** — minimal generic trait mirroring \`PublicKeyParts<T>\` in shape. Only accessor is \`d()\`. CRT methods (dp/dq/qinv/p_params/q_params) deliberately omitted; they'll arrive on a future \`GenericCrtPrivateKeyParts\` extension trait when CT modular inverse lands upstream.

**\`key::GenericRsaPrivateKey<T, M>\`** — heapless-compatible value type holding \`(GenericRsaPublicKey<T, M>, d: T)\`. No \`Vec<...>\` primes storage, no \`Option<PrecomputedValues>\` — just the raw \`(n, e, d)\` shape suitable for the sign primitives we landed in PRs #19-#22. \`Drop\` + \`ZeroizeOnDrop\` for \`d\`. Public components stay reachable via \`as_public()\`.

**Bridge:** blanket \`impl GenericPrivateKeyParts<BoxedUint, BoxedMontyParams> for K where K: PrivateKeyParts + PublicKeyParts<BoxedUint, MontyParams = BoxedMontyParams>\`. Existing \`RsaPrivateKey\` (alloc) instantly satisfies the new generic at the concrete BoxedUint substitution, so future PRs can re-bind the upstream-aligned \`algorithms::rsa::rsa_decrypt[_and_check]\` consumers on the generic trait without breaking compilation.

## Gating

Both items behind \`cfg(any(feature = "private-key", feature = "wip-private-key"))\` so the heapless path picks them up alongside the alloc path.

## Test plan

\`generic_rsa_private_key_satisfies_traits\`:
- Constructs a \`GenericRsaPrivateKey<SmallUCt, ModMathParams<SmallUCt, Ct>>\` via \`from_components\`.
- Asserts it satisfies \`PublicKeyParts\` AND \`GenericPrivateKeyParts\` at matching (T, M) substitutions via fn-bound checks (compile-time proof).
- Exercises the round-trip accessors (\`d()\`, \`e()\`).

Verified:
- \`cargo test --lib\` — 89/89 passing (was 88, +1 new).
- \`cargo test --lib --no-default-features --features modmath,wip-private-key\` — 13 tests pass (was 12, +1 new).
- \`cargo check\` (default), \`--no-default-features\`, \`--no-default-features --features modmath\` — all green.
- \`cargo clippy --all -- -D warnings\` + \`cargo fmt --check\` — clean.

## Scope

\`#[allow(dead_code)]\` on \`GenericRsaPrivateKey\`'s inherent impl — \`from_components\` and \`as_public\` have no caller in non-test code yet; the heapless \`pkcs1v15::SigningKey<D>\` / \`pss::SigningKey<D>\` wrappers land in Phase 2 and become the real consumers.

No behavior change on the alloc side.

Net: +187 lines across four files.

## Summary by Sourcery

Introduce a generic, heapless-friendly RSA private key representation and trait, and bridge existing alloc-backed keys to the new abstraction behind private-key feature gates.

New Features:
- Add GenericRsaPrivateKey<T, M> value type that stores RSA public components and private exponent without heap-allocated primes or precomputed CRT data.
- Define GenericPrivateKeyParts<T, M> trait as a minimal, integer- and modulus-agnostic RSA private key interface exposing the private exponent.

Enhancements:
- Bridge legacy PrivateKeyParts implementations to GenericPrivateKeyParts<BoxedUint, BoxedMontyParams> so existing alloc-side keys satisfy the new generic trait.
- Ensure GenericRsaPrivateKey<T, M> zeroizes the private exponent on drop to maintain secret key hygiene.
- Re-export GenericPrivateKeyParts from the top-level traits module under the appropriate private-key feature flags.

Tests:
- Add generic_rsa_private_key_satisfies_traits test to assert trait satisfaction for GenericRsaPrivateKey and validate public/private accessor round-trips under heapless modmath parameters.