### PR TITLE
Phase 2a: heapless GenericSigningKey for PKCS#1 v1.5

### DIFF
--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1099,6 +1099,46 @@ mod private_op_tests {
     // ─── Phase 1 trait surgery: GenericPrivateKeyParts smoke tests ──────
 
     #[test]
+    fn pkcs1v15_signing_key_round_trip_2048_sha1() {
+        use crate::key::{GenericRsaPrivateKey, GenericRsaPublicKey};
+        use crate::pkcs1v15::{GenericSignature, GenericSigningKey, GenericVerifyingKey};
+        use digest::Digest;
+        use sha1::Sha1;
+        use signature::hazmat::PrehashVerifier;
+
+        type U2048 = FixedUInt<u8, 256, Ct>;
+        const K: usize = 256;
+
+        let public =
+            crate::modmath_support::public_key_ct_from_be_bytes::<U2048>(&N_2048, 65537).unwrap();
+        let public_clone: GenericRsaPublicKey<ModMathValue<U2048>, ModMathParams<U2048, Ct>> =
+            public.clone();
+        let d = wrap_value(
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
+        );
+        let priv_key = GenericRsaPrivateKey::from_components(public, d);
+
+        let signing_key = GenericSigningKey::<Sha1, _, _>::new(priv_key);
+        let verifying_key = GenericVerifyingKey::<Sha1, _, _>::new(public_clone);
+
+        let msg: &[u8] = b"deterministic test message";
+        let mut em_storage = [0u8; K];
+        let mut sig_storage = [0u8; K];
+        let sig_slice = signing_key
+            .try_sign_into(msg, &mut em_storage, &mut sig_storage)
+            .unwrap();
+        assert_eq!(sig_slice.len(), K);
+
+        // Round-trip: build a `GenericSignature` over the same modulus type
+        // and verify against the prehash via the existing verifier.
+        let sig_int =
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(sig_slice).unwrap();
+        let sig = GenericSignature::from(wrap_value(sig_int));
+        let digest = Sha1::digest(msg);
+        verifying_key.verify_prehash(&digest, &sig).unwrap();
+    }
+
+    #[test]
     fn generic_rsa_private_key_satisfies_traits() {
         // Compile-time assertion: GenericRsaPrivateKey<SmallUCt, ModMathParams<SmallUCt, Ct>>
         // satisfies both PublicKeyParts and GenericPrivateKeyParts at the

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1139,6 +1139,51 @@ mod private_op_tests {
     }
 
     #[test]
+    fn pkcs1v15_signing_key_rejects_wrong_prehash_length() {
+        use crate::key::GenericRsaPrivateKey;
+        use crate::pkcs1v15::GenericSigningKey;
+        use sha1::Sha1;
+
+        type U2048 = FixedUInt<u8, 256, Ct>;
+        const K: usize = 256;
+
+        let public =
+            crate::modmath_support::public_key_ct_from_be_bytes::<U2048>(&N_2048, 65537).unwrap();
+        let d = wrap_value(
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
+        );
+        let priv_key = GenericRsaPrivateKey::from_components(public, d);
+        let signing_key = GenericSigningKey::<Sha1, _, _>::new(priv_key);
+
+        let bad_prehash = [0u8; 21]; // SHA-1 outputs 20 bytes, not 21.
+        let mut em_storage = [0u8; K];
+        let mut sig_storage = [0u8; K];
+        let result =
+            signing_key.try_sign_prehash_into(&bad_prehash, &mut em_storage, &mut sig_storage);
+        assert!(matches!(result, Err(Error::InputNotHashed)));
+    }
+
+    #[test]
+    fn pkcs1v15_signing_key_satisfies_zeroize() {
+        use crate::key::GenericRsaPrivateKey;
+        use crate::pkcs1v15::GenericSigningKey;
+        use sha1::Sha1;
+        fn assert_zeroize<Z: Zeroize>() {}
+        assert_zeroize::<
+            GenericSigningKey<Sha1, ModMathValue<SmallUCt>, ModMathParams<SmallUCt, Ct>>,
+        >();
+
+        // Construct one and exercise .zeroize() at runtime to confirm the
+        // delegation compiles end-to-end.
+        let public =
+            crate::modmath_support::public_key_ct_from_be_bytes::<SmallUCt>(&[35u8], 5).unwrap();
+        let priv_key =
+            GenericRsaPrivateKey::from_components(public, wrap_value(SmallUCt::from(29u8)));
+        let mut signing_key = GenericSigningKey::<Sha1, _, _>::new(priv_key);
+        signing_key.zeroize();
+    }
+
+    #[test]
     fn generic_rsa_private_key_satisfies_traits() {
         // Compile-time assertion: GenericRsaPrivateKey<SmallUCt, ModMathParams<SmallUCt, Ct>>
         // satisfies both PublicKeyParts and GenericPrivateKeyParts at the

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -29,11 +29,15 @@
 #[cfg(feature = "private-key")]
 mod decrypting_key;
 mod encrypting_key;
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+mod generic_signing_key;
 mod signature;
 #[cfg(feature = "private-key")]
 mod signing_key;
 mod verifying_key;
 
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub use self::generic_signing_key::GenericSigningKey;
 #[cfg(feature = "private-key")]
 pub use self::{
     decrypting_key::DecryptingKey,

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -135,12 +135,19 @@ where
     /// Sign a precomputed `prehash` (`D::output_size()` bytes) into
     /// `sig_storage`. The caller is responsible for the hash; this skips
     /// the internal `D::digest(msg)` step.
+    ///
+    /// Returns [`Error::InputNotHashed`] if `prehash.len()` doesn't match
+    /// `D::output_size()` — a mismatch would silently produce malformed
+    /// PKCS#1 v1.5 padding rather than a usable signature.
     pub fn try_sign_prehash_into<'sig>(
         &self,
         prehash: &[u8],
         em_storage: &mut [u8],
         sig_storage: &'sig mut [u8],
     ) -> Result<&'sig [u8]> {
+        if prehash.len() != <D as Digest>::output_size() {
+            return Err(crate::errors::Error::InputNotHashed);
+        }
         let k = self.inner.size();
         sign_into(
             self.inner.n_params(),
@@ -152,6 +159,22 @@ where
             em_storage,
             sig_storage,
         )
+    }
+}
+
+// Allow callers to wrap a `GenericSigningKey` in `zeroize::Zeroizing<_>`
+// or invoke `.zeroize()` directly. The prefix is public DigestInfo
+// material; only the inner `GenericRsaPrivateKey` carries secret bytes.
+// Same pattern as the canonical Zeroize impls on `GenericRsaPrivateKey`
+// (PR #24) and `ModMathForm` (PR #17).
+impl<D, T, M> Zeroize for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    fn zeroize(&mut self) {
+        self.inner.zeroize();
     }
 }
 

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -1,0 +1,173 @@
+//! Heapless `RSASSA-PKCS1-v1_5` signing key. Generic over `D` (digest),
+//! `T` (integer), and `M` (Montgomery parameters), mirrors the shape of
+//! [`super::GenericVerifyingKey`] on the verify side.
+//!
+//! Compatible with the no_alloc / `wip-private-key` build path —
+//! [`GenericRsaPrivateKey<T, M>`] storage, fixed-size [`Prefix`] for
+//! the DigestInfo prefix, caller-supplied scratch buffers for the EM
+//! and signature output.
+
+use super::sign_into;
+#[cfg(feature = "alloc")]
+use super::{pkcs1v15_generate_prefix, GenericVerifyingKey};
+#[cfg(not(feature = "alloc"))]
+use super::{pkcs1v15_generate_prefix_helper, Prefix};
+use crate::{
+    errors::Result,
+    key::GenericRsaPrivateKey,
+    traits::{
+        modular::{ModulusParams, Pow, PowBoundedExp},
+        PublicKeyParts, UnsignedModularInt,
+    },
+};
+use const_oid::AssociatedOid;
+use core::marker::PhantomData;
+use digest::Digest;
+use zeroize::Zeroize;
+
+/// Signing key for `RSASSA-PKCS1-v1_5` signatures — heapless variant.
+///
+/// Generic over the digest `D`, integer type `T`, and Montgomery parameters
+/// `M`. Holds a [`GenericRsaPrivateKey<T, M>`] plus the precomputed
+/// DigestInfo prefix for `D`.
+#[derive(Clone)]
+pub struct GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    pub(super) inner: GenericRsaPrivateKey<T, M>,
+    #[cfg(feature = "alloc")]
+    pub(super) prefix: alloc::vec::Vec<u8>,
+    #[cfg(not(feature = "alloc"))]
+    pub(super) prefix: Prefix,
+    pub(super) phantom: PhantomData<D>,
+}
+
+impl<D, T, M> GenericSigningKey<D, T, M>
+where
+    D: Digest + AssociatedOid,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    /// Create a new signing key with a precomputed prefix for digest `D`.
+    pub fn new(key: GenericRsaPrivateKey<T, M>) -> Self {
+        Self {
+            inner: key,
+            #[cfg(feature = "alloc")]
+            prefix: pkcs1v15_generate_prefix::<D>(),
+            #[cfg(not(feature = "alloc"))]
+            prefix: pkcs1v15_generate_prefix_helper::<D>(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<D, T, M> GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    /// Create a new signing key with an empty prefix (raw signatures, no
+    /// DigestInfo wrapper). Unusual — most callers want [`new`] instead.
+    pub fn new_unprefixed(key: GenericRsaPrivateKey<T, M>) -> Self {
+        Self {
+            inner: key,
+            #[cfg(feature = "alloc")]
+            prefix: alloc::vec::Vec::new(),
+            #[cfg(not(feature = "alloc"))]
+            prefix: Prefix::new(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+// Borrow the inner private-key components — `AsRef` impl mirrors
+// the verifier's `AsRef<GenericRsaPublicKey<T, M>>` (`verifying_key.rs:172`).
+impl<D, T, M> AsRef<GenericRsaPrivateKey<T, M>> for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    fn as_ref(&self) -> &GenericRsaPrivateKey<T, M> {
+        &self.inner
+    }
+}
+
+impl<D, T, M> GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+    M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
+{
+    /// Sign `msg` (hashed internally with `D`) into `sig_storage`.
+    /// Uses `em_storage` as scratch for the EM encoding.
+    ///
+    /// Both buffers must be at least `self.inner.size()` bytes.
+    /// Mirrors the shape of
+    /// [`crate::traits::RandomizedEncryptor::encrypt_with_rng_into`] on
+    /// the encrypt side: caller owns storage, returned slice borrows from
+    /// `sig_storage` with the same lifetime.
+    pub fn try_sign_into<'sig>(
+        &self,
+        msg: &[u8],
+        em_storage: &mut [u8],
+        sig_storage: &'sig mut [u8],
+    ) -> Result<&'sig [u8]> {
+        let digest = D::digest(msg);
+        let k = self.inner.size();
+        sign_into(
+            self.inner.n_params(),
+            crate::traits::keys::GenericPrivateKeyParts::d(&self.inner),
+            self.inner.e(),
+            self.prefix.as_ref(),
+            digest.as_ref(),
+            k,
+            em_storage,
+            sig_storage,
+        )
+    }
+
+    /// Sign a precomputed `prehash` (`D::output_size()` bytes) into
+    /// `sig_storage`. The caller is responsible for the hash; this skips
+    /// the internal `D::digest(msg)` step.
+    pub fn try_sign_prehash_into<'sig>(
+        &self,
+        prehash: &[u8],
+        em_storage: &mut [u8],
+        sig_storage: &'sig mut [u8],
+    ) -> Result<&'sig [u8]> {
+        let k = self.inner.size();
+        sign_into(
+            self.inner.n_params(),
+            crate::traits::keys::GenericPrivateKeyParts::d(&self.inner),
+            self.inner.e(),
+            self.prefix.as_ref(),
+            prehash,
+            k,
+            em_storage,
+            sig_storage,
+        )
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<D, T, M> GenericSigningKey<D, T, M>
+where
+    D: Digest + AssociatedOid,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    /// Derive the matching [`GenericVerifyingKey`] from this signing key.
+    pub fn verifying_key(&self) -> GenericVerifyingKey<D, T, M>
+    where
+        GenericRsaPrivateKey<T, M>: Clone,
+        crate::key::GenericRsaPublicKey<T, M>: Clone,
+    {
+        GenericVerifyingKey::new(self.inner.as_public().clone())
+    }
+}


### PR DESCRIPTION
## Summary

User-facing wrapper consuming the Phase 1 trait surgery (\`GenericRsaPrivateKey\` + \`GenericPrivateKeyParts\` from PR #24). Mirrors the existing \`GenericVerifyingKey<D, T, M>\` shape so the matching pair is symmetric — this is the heapless counterpart that closes the sign+verify story for PKCS#1 v1.5.

## What lands

New file \`pkcs1v15/generic_signing_key.rs\`:

- **\`GenericSigningKey<D, T, M>\`** — owns a \`GenericRsaPrivateKey<T, M>\` plus the precomputed DigestInfo prefix (alloc: \`Vec<u8>\`, no_alloc: existing \`Prefix<32>\`). \`PhantomData<D>\` for digest type.
- **\`new(key)\`** constructs with the standard prefix for digest \`D: Digest + AssociatedOid\`; **\`new_unprefixed(key)\`** for raw signatures.
- **\`AsRef<GenericRsaPrivateKey<T, M>>\`** for inspecting the inner key.
- **\`try_sign_into(msg, em_storage, sig_storage) -> Result<&[u8]>\`** — hashes \`msg\` with \`D\`, calls \`pkcs1v15::sign_into\`. Slice-output, caller-owned storage — same shape as \`RandomizedEncryptor::encrypt_with_rng_into\` on the encrypt side (no new traits invented).
- **\`try_sign_prehash_into(prehash, ...)\`** — same body, skipping the internal hash.
- Alloc-gated **\`verifying_key(&self)\`** constructs the matching \`GenericVerifyingKey<D, T, M>\`.

## Gating

Module declaration + re-export both \`cfg(any(feature = "private-key", feature = "wip-private-key"))\` so the heapless path picks it up. The existing alloc-only \`SigningKey<D>\` (wrapping \`RsaPrivateKey\`) is unchanged.

## Test plan

\`pkcs1v15_signing_key_round_trip_2048_sha1\` exercises the full chain end-to-end with the 2048-bit \`(n, e=65537, d)\` fixture from earlier PRs:
- Constructs both \`GenericSigningKey<Sha1, ...>\` and \`GenericVerifyingKey<Sha1, ...>\` over the same modulus.
- Signs a deterministic test message via \`try_sign_into\`.
- Verifies via the existing \`verify_prehash\`.

Verified:
- \`cargo test --lib\` — 90/90 passing (was 89, +1 new).
- \`cargo test --lib --no-default-features --features modmath,wip-private-key\` — 14 tests pass (was 13).
- \`cargo check\` (default), \`--no-default-features\`, \`--no-default-features --features modmath\` — all green.
- \`cargo clippy --all -- -D warnings\` + \`cargo fmt --check\` — clean.

## Scope

PSS counterpart (\`pss::GenericSigningKey<D, T, M>\`) lands as a follow-up PR (Phase 2b) with the same shape but RNG-taking method for the PSS salt.

Net: +217 lines, mostly the new file.

## Summary by Sourcery

Introduce a heapless, generic PKCS#1 v1.5 signing key and wire it into the existing PKCS#1 v1.5 module alongside tests that validate sign/verify round trips.

New Features:
- Add GenericSigningKey<D, T, M> for RSASSA-PKCS1-v1_5 signatures over GenericRsaPrivateKey, supporting both alloc and no-alloc builds.
- Expose GenericSigningKey from the pkcs1v15 module under private-key and wip-private-key feature gates.
- Provide methods to construct prefixed and unprefixed signing keys and to produce signatures from messages or precomputed digests in caller-supplied buffers.

Tests:
- Add pkcs1v15_signing_key_round_trip_2048_sha1 test that exercises heapless signing and verification end-to-end for a 2048-bit key pair.