### PR TITLE
Phase 2b: heapless GenericSigningKey for RSASSA-PSS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,8 @@ pub use crate::{
     pkcs1v15::{Pkcs1v15Encrypt, Pkcs1v15Sign},
 };
 
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub use crate::key::GenericRsaPrivateKey;
 #[cfg(feature = "private-key")]
 pub use crate::key::RsaPrivateKey;
 

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1164,6 +1164,93 @@ mod private_op_tests {
     }
 
     #[test]
+    fn pss_signing_key_round_trip_2048_sha1() {
+        use crate::algorithms::pss::emsa_pss_verify;
+        use crate::key::GenericRsaPrivateKey;
+        use crate::pss::GenericSigningKey;
+        use digest::Digest;
+        use sha1::Sha1;
+
+        type U2048 = FixedUInt<u8, 256, Ct>;
+        const K: usize = 256;
+        const KEY_BITS: usize = 2048;
+
+        let key =
+            crate::modmath_support::public_key_ct_from_be_bytes::<U2048>(&N_2048, 65537).unwrap();
+        let d = wrap_value(
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
+        );
+        let priv_key = GenericRsaPrivateKey::from_components(key.clone(), d);
+        // Salt length = 0 → deterministic encoding, easy roundtrip.
+        let signing_key = GenericSigningKey::<Sha1, _, _>::new_with_salt_len(priv_key, 0);
+
+        let msg: &[u8] = b"pss-roundtrip test message";
+        let digest = Sha1::digest(msg);
+        let mut em_storage = [0u8; K];
+        let mut sig_storage = [0u8; K];
+        let sig_slice = signing_key
+            .try_sign_prehash_with_salt_into(&digest, &[], &mut em_storage, &mut sig_storage)
+            .unwrap();
+        assert_eq!(sig_slice.len(), K);
+
+        // Roundtrip: `sig^e mod n` should yield a valid PSS-encoded EM
+        // for `(digest, salt_len=0)`. `emsa_pss_verify` modifies em
+        // in place (MGF unmask), so copy first.
+        let recovered = public_key_op_ct(&key, sig_slice).unwrap();
+        let mut em_copy = [0u8; K];
+        em_copy.copy_from_slice(recovered.as_ref());
+        let mut verify_hash = Sha1::new();
+        emsa_pss_verify(&digest, &mut em_copy, Some(0), &mut verify_hash, KEY_BITS).unwrap();
+    }
+
+    #[test]
+    fn pss_signing_key_rejects_wrong_prehash_length() {
+        use crate::key::GenericRsaPrivateKey;
+        use crate::pss::GenericSigningKey;
+        use sha1::Sha1;
+
+        type U2048 = FixedUInt<u8, 256, Ct>;
+        const K: usize = 256;
+
+        let key =
+            crate::modmath_support::public_key_ct_from_be_bytes::<U2048>(&N_2048, 65537).unwrap();
+        let d = wrap_value(
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
+        );
+        let priv_key = GenericRsaPrivateKey::from_components(key, d);
+        let signing_key = GenericSigningKey::<Sha1, _, _>::new_with_salt_len(priv_key, 0);
+
+        let bad_prehash = [0u8; 21]; // SHA-1 is 20 bytes.
+        let mut em_storage = [0u8; K];
+        let mut sig_storage = [0u8; K];
+        let result = signing_key.try_sign_prehash_with_salt_into(
+            &bad_prehash,
+            &[],
+            &mut em_storage,
+            &mut sig_storage,
+        );
+        assert!(matches!(result, Err(Error::InputNotHashed)));
+    }
+
+    #[test]
+    fn pss_signing_key_satisfies_zeroize() {
+        use crate::key::GenericRsaPrivateKey;
+        use crate::pss::GenericSigningKey;
+        use sha1::Sha1;
+        fn assert_zeroize<Z: Zeroize>() {}
+        assert_zeroize::<
+            GenericSigningKey<Sha1, ModMathValue<SmallUCt>, ModMathParams<SmallUCt, Ct>>,
+        >();
+
+        let public =
+            crate::modmath_support::public_key_ct_from_be_bytes::<SmallUCt>(&[35u8], 5).unwrap();
+        let priv_key =
+            GenericRsaPrivateKey::from_components(public, wrap_value(SmallUCt::from(29u8)));
+        let mut signing_key = GenericSigningKey::<Sha1, _, _>::new(priv_key);
+        signing_key.zeroize();
+    }
+
+    #[test]
     fn pkcs1v15_signing_key_satisfies_zeroize() {
         use crate::key::GenericRsaPrivateKey;
         use crate::pkcs1v15::GenericSigningKey;

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1233,6 +1233,37 @@ mod private_op_tests {
     }
 
     #[test]
+    fn pss_signing_key_rejects_salt_len_mismatch() {
+        use crate::key::GenericRsaPrivateKey;
+        use crate::pss::GenericSigningKey;
+        use sha1::Sha1;
+
+        type U2048 = FixedUInt<u8, 256, Ct>;
+        const K: usize = 256;
+
+        let key =
+            crate::modmath_support::public_key_ct_from_be_bytes::<U2048>(&N_2048, 65537).unwrap();
+        let d = wrap_value(
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
+        );
+        let priv_key = GenericRsaPrivateKey::from_components(key, d);
+        // salt_len configured to 20; supply 16 -> mismatch.
+        let signing_key = GenericSigningKey::<Sha1, _, _>::new_with_salt_len(priv_key, 20);
+
+        let prehash = [0u8; 20];
+        let wrong_salt = [0u8; 16];
+        let mut em_storage = [0u8; K];
+        let mut sig_storage = [0u8; K];
+        let result = signing_key.try_sign_prehash_with_salt_into(
+            &prehash,
+            &wrong_salt,
+            &mut em_storage,
+            &mut sig_storage,
+        );
+        assert!(matches!(result, Err(Error::InvalidArguments)));
+    }
+
+    #[test]
     fn pss_signing_key_satisfies_zeroize() {
         use crate::key::GenericRsaPrivateKey;
         use crate::pss::GenericSigningKey;

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -11,11 +11,15 @@
 
 #[cfg(feature = "private-key")]
 mod blinded_signing_key;
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+mod generic_signing_key;
 mod signature;
 #[cfg(feature = "private-key")]
 mod signing_key;
 mod verifying_key;
 
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub use self::generic_signing_key::GenericSigningKey;
 #[cfg(feature = "private-key")]
 pub use self::{blinded_signing_key::BlindedSigningKey, signing_key::SigningKey};
 

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -158,7 +158,10 @@ where
     /// Sign with caller-supplied salt — useful for determinism in tests.
     ///
     /// Returns [`Error::InputNotHashed`] if `prehash.len()` doesn't match
-    /// `D::output_size()`.
+    /// `D::output_size()`. Returns [`Error::InvalidArguments`] if
+    /// `salt.len() != self.salt_len()` — a mismatch silently produces a
+    /// signature that no verifier configured with the key's advertised
+    /// `salt_len` will accept, so we reject it up front.
     pub fn try_sign_prehash_with_salt_into<'sig>(
         &self,
         prehash: &[u8],
@@ -168,6 +171,9 @@ where
     ) -> Result<&'sig [u8]> {
         if prehash.len() != <D as Digest>::output_size() {
             return Err(Error::InputNotHashed);
+        }
+        if salt.len() != self.salt_len {
+            return Err(Error::InvalidArguments);
         }
         let mut hash = D::new();
         sign_into(

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -1,0 +1,199 @@
+//! Heapless RSASSA-PSS signing key. Generic over `D` (digest),
+//! `T` (integer), and `M` (Montgomery parameters), mirrors
+//! [`super::GenericVerifyingKey`] on the verify side and the
+//! [`crate::pkcs1v15::GenericSigningKey`] shape for the sign side.
+//!
+//! PSS sign needs an RNG for the salt (unlike PKCS#1 v1.5 sign which
+//! is deterministic) — `try_sign_with_rng_into` mirrors the
+//! `RandomizedEncryptor::encrypt_with_rng_into` shape on the encrypt
+//! side: caller passes `&mut R: TryCryptoRng + ?Sized`.
+
+use crate::{
+    algorithms::pss::sign_into,
+    errors::{Error, Result},
+    key::GenericRsaPrivateKey,
+    traits::{
+        modular::{ModulusParams, Pow, PowBoundedExp},
+        PublicKeyParts, UnsignedModularInt,
+    },
+};
+use core::marker::PhantomData;
+use digest::{Digest, FixedOutputReset};
+use rand_core::TryCryptoRng;
+use zeroize::Zeroize;
+
+/// Signing key for RSASSA-PSS — heapless variant.
+///
+/// Generic over the digest `D`, integer type `T`, and Montgomery parameters
+/// `M`. Holds a [`GenericRsaPrivateKey<T, M>`] plus the salt length to use
+/// when signing (caller-chosen at construction; defaults to
+/// `<D as Digest>::output_size()` via [`new`](Self::new)).
+///
+/// PSS has no DigestInfo prefix — `D` is purely a phantom marker for the
+/// digest algorithm used by both encode and verify.
+#[derive(Clone)]
+pub struct GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    pub(super) inner: GenericRsaPrivateKey<T, M>,
+    pub(super) salt_len: usize,
+    pub(super) phantom: PhantomData<D>,
+}
+
+impl<D, T, M> GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    /// Construct with salt length = `D::output_size()` (standard choice
+    /// per RFC 8017 § 8.1).
+    pub fn new(key: GenericRsaPrivateKey<T, M>) -> Self {
+        Self {
+            inner: key,
+            salt_len: <D as Digest>::output_size(),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Construct with a custom salt length.
+    pub fn new_with_salt_len(key: GenericRsaPrivateKey<T, M>, salt_len: usize) -> Self {
+        Self {
+            inner: key,
+            salt_len,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Salt length this key will use when signing.
+    pub fn salt_len(&self) -> usize {
+        self.salt_len
+    }
+}
+
+// Borrow the inner private-key components — `AsRef` impl mirrors
+// the verifier's `AsRef<GenericRsaPublicKey<T, M>>`.
+impl<D, T, M> AsRef<GenericRsaPrivateKey<T, M>> for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    fn as_ref(&self) -> &GenericRsaPrivateKey<T, M> {
+        &self.inner
+    }
+}
+
+impl<D, T, M> GenericSigningKey<D, T, M>
+where
+    D: Digest + FixedOutputReset,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+    M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
+{
+    /// Sign `msg` (hashed internally with `D`) into `sig_storage`, drawing
+    /// the PSS salt from `rng`. Uses `em_storage` and `salt_storage` as
+    /// scratch. All three buffers must be at least the relevant sizes
+    /// (`em_storage`: `em_bits.div_ceil(8)`; `sig_storage`: `n.size()`;
+    /// `salt_storage`: `self.salt_len()`).
+    ///
+    /// Mirrors [`crate::traits::RandomizedEncryptor::encrypt_with_rng_into`]:
+    /// caller owns storage, returned slice borrows from `sig_storage`.
+    pub fn try_sign_with_rng_into<'sig, R: TryCryptoRng + ?Sized>(
+        &self,
+        rng: &mut R,
+        msg: &[u8],
+        em_storage: &mut [u8],
+        sig_storage: &'sig mut [u8],
+        salt_storage: &mut [u8],
+    ) -> Result<&'sig [u8]> {
+        let digest = D::digest(msg);
+        self.try_sign_prehash_with_rng_into(
+            rng,
+            digest.as_ref(),
+            em_storage,
+            sig_storage,
+            salt_storage,
+        )
+    }
+
+    /// Sign a precomputed `prehash` (`D::output_size()` bytes) into
+    /// `sig_storage`, drawing the PSS salt from `rng`.
+    ///
+    /// Returns [`Error::InputNotHashed`] if `prehash.len()` doesn't match
+    /// `D::output_size()`. Returns [`Error::OutputBufferTooSmall`] if
+    /// `salt_storage.len() < self.salt_len()`.
+    pub fn try_sign_prehash_with_rng_into<'sig, R: TryCryptoRng + ?Sized>(
+        &self,
+        rng: &mut R,
+        prehash: &[u8],
+        em_storage: &mut [u8],
+        sig_storage: &'sig mut [u8],
+        salt_storage: &mut [u8],
+    ) -> Result<&'sig [u8]> {
+        if prehash.len() != <D as Digest>::output_size() {
+            return Err(Error::InputNotHashed);
+        }
+        let salt = salt_storage
+            .get_mut(..self.salt_len)
+            .ok_or(Error::OutputBufferTooSmall)?;
+        rng.try_fill_bytes(salt).map_err(|_| Error::Rng)?;
+        let mut hash = D::new();
+        sign_into(
+            self.inner.n_params(),
+            crate::traits::keys::GenericPrivateKeyParts::d(&self.inner),
+            self.inner.e(),
+            prehash,
+            salt,
+            self.inner.size(),
+            &mut hash,
+            em_storage,
+            sig_storage,
+        )
+    }
+
+    /// Sign with caller-supplied salt — useful for determinism in tests.
+    ///
+    /// Returns [`Error::InputNotHashed`] if `prehash.len()` doesn't match
+    /// `D::output_size()`.
+    pub fn try_sign_prehash_with_salt_into<'sig>(
+        &self,
+        prehash: &[u8],
+        salt: &[u8],
+        em_storage: &mut [u8],
+        sig_storage: &'sig mut [u8],
+    ) -> Result<&'sig [u8]> {
+        if prehash.len() != <D as Digest>::output_size() {
+            return Err(Error::InputNotHashed);
+        }
+        let mut hash = D::new();
+        sign_into(
+            self.inner.n_params(),
+            crate::traits::keys::GenericPrivateKeyParts::d(&self.inner),
+            self.inner.e(),
+            prehash,
+            salt,
+            self.inner.size(),
+            &mut hash,
+            em_storage,
+            sig_storage,
+        )
+    }
+}
+
+// Allow callers to wrap a `GenericSigningKey` in `zeroize::Zeroizing<_>`
+// or invoke `.zeroize()` directly. The salt_len is public; only the
+// inner `GenericRsaPrivateKey` carries secret bytes.
+impl<D, T, M> Zeroize for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
+    fn zeroize(&mut self) {
+        self.inner.zeroize();
+    }
+}


### PR DESCRIPTION
## Summary

PSS counterpart to the PKCS#1 v1.5 wrapper landed in PR #25. RSASSA-PSS is the TLS 1.3-mandated signature algorithm (RFC 8446 § 4.2.3 bans PKCS#1 v1.5 for CertificateVerify) — this is the load-bearing user-facing surface for the heapless TLS client-cert use case.

## What lands

New file \`pss/generic_signing_key.rs\`:

- **\`GenericSigningKey<D, T, M>\`** — owns \`GenericRsaPrivateKey<T, M>\` plus the salt length. No DigestInfo prefix (PSS doesn't use one); \`PhantomData<D>\` for the digest type.
- **\`new(key)\`** — salt_len defaults to \`<D as Digest>::output_size()\` per RFC 8017 § 8.1. **\`new_with_salt_len(key, salt_len)\`** for callers that want a different (e.g. zero) length. **\`salt_len()\`** accessor.
- **\`AsRef<GenericRsaPrivateKey<T, M>>\`** matches the pkcs1v15 sibling.
- **\`try_sign_with_rng_into(rng, msg, em_storage, sig_storage, salt_storage)\`** — hashes \`msg\` internally, draws the PSS salt from \`rng: &mut R: TryCryptoRng + ?Sized\`. Mirrors \`RandomizedEncryptor::encrypt_with_rng_into\` on the encrypt side; no new traits invented per the user direction.
- **\`try_sign_prehash_with_rng_into(...)\`** — same, callers with a precomputed digest. Validates \`prehash.len() == D::output_size()\` up front (mirrors PR #25's security-high fix).
- **\`try_sign_prehash_with_salt_into(prehash, salt, ...)\`** — caller supplies the salt directly (useful for deterministic tests). Same length check.
- **\`impl Zeroize\`** delegating to \`self.inner.zeroize()\` so callers can wrap in \`Zeroizing<_>\`. Mirrors the canonical pattern from PR #24 / #25 / PR #17.

## Gating

Module declaration + re-export both \`cfg(any(feature = "private-key", feature = "wip-private-key"))\`. Existing alloc-only \`pss::SigningKey<D>\` (wrapping \`RsaPrivateKey\`) unchanged.

## Test plan

Three new tests:
- **\`pss_signing_key_round_trip_2048_sha1\`** — end-to-end with the 2048-bit \`(n, e=65537, d)\` fixture and \`salt_len=0\` for determinism. After sign, \`sig^e mod n\` via \`rsa_public_op_ct\` recovers the EM; verified by \`emsa_pss_verify\` against the same \`(digest, salt_len)\`.
- **\`pss_signing_key_rejects_wrong_prehash_length\`** — passes a 21-byte prehash to a SHA-1 signer; expects \`Err(Error::InputNotHashed)\`.
- **\`pss_signing_key_satisfies_zeroize\`** — compile-time trait check plus runtime \`.zeroize()\` call.

Verified:
- \`cargo test --lib\` — 95/95 passing (was 92, +3 new).
- \`cargo test --lib --no-default-features --features modmath,wip-private-key\` — 19 tests pass (was 16, +3 new).
- \`cargo check\` (default), \`--no-default-features\`, \`--no-default-features --features modmath\` — all green.
- \`cargo clippy --all -- -D warnings\` + \`cargo fmt --check\` — clean.

## Scope

This closes the Phase 2 user-facing surface — both PKCS#1 v1.5 and PSS signing have heapless wrappers that consume \`GenericRsaPrivateKey<T, M>\` and produce slice-output signatures via the existing sign primitives.

Net: +290 lines, mostly the new file.

## Summary by Sourcery

Introduce a heapless, generic RSASSA-PSS signing key that parallels the existing PKCS#1 v1.5 generic signing surface and wire it into the PSS module behind private-key feature gates.

New Features:
- Add GenericSigningKey for RSASSA-PSS that is generic over digest, integer, and Montgomery parameters and wraps GenericRsaPrivateKey with configurable salt length.
- Expose heapless PSS signing APIs that support both internal hashing and prehashed inputs, with RNG- and caller-supplied salt variants.

Enhancements:
- Re-export the new GenericSigningKey from the PSS module when private-key or wip-private-key features are enabled to complete the heapless signing surface.

Tests:
- Add round-trip RSASSA-PSS signing test for a 2048-bit SHA-1 key with deterministic salt to validate encoding and public-key recovery.
- Add test ensuring RSASSA-PSS GenericSigningKey rejects prehash inputs of incorrect length with InputNotHashed error.
- Add test verifying GenericSigningKey implements Zeroize and that zeroization can be invoked at runtime.