### PR TITLE
Fold-1: alloc-side algorithm consumes GenericPrivateKeyParts

### DIFF
--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -18,7 +18,7 @@ use zeroize::Zeroize;
 #[cfg(not(feature = "private-key"))]
 use crate::traits::keys::PublicKeyParts;
 #[cfg(feature = "private-key")]
-use crate::traits::keys::{PrivateKeyParts, PublicKeyParts};
+use crate::traits::keys::{GenericPrivateKeyParts, PublicKeyParts};
 use crate::{
     errors::{Error, Result},
     traits::{
@@ -54,13 +54,16 @@ where
 /// or signature scheme. See the [module-level documentation][crate::hazmat] for more information.
 #[cfg(feature = "private-key")]
 #[inline]
-pub fn rsa_decrypt<R: TryCryptoRng + ?Sized>(
+pub fn rsa_decrypt<R: TryCryptoRng + ?Sized, K>(
     rng: Option<&mut R>,
-    priv_key: &impl PrivateKeyParts<MontyParams = BoxedMontyParams>,
+    priv_key: &K,
     c: &BoxedUint,
-) -> Result<BoxedUint> {
+) -> Result<BoxedUint>
+where
+    K: GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
+{
     let n = priv_key.n();
-    let d = priv_key.d();
+    let d = GenericPrivateKeyParts::d(priv_key);
 
     if c.bits_precision() != n.as_ref().bits_precision() {
         return Err(Error::Decryption);
@@ -83,20 +86,20 @@ pub fn rsa_decrypt<R: TryCryptoRng + ?Sized>(
         c.try_resize(bits).ok_or(Error::Internal)?
     };
 
-    let is_multiprime = priv_key.primes().len() > 2;
+    let is_multiprime = GenericPrivateKeyParts::primes(priv_key).len() > 2;
 
     let m = match (
-        priv_key.dp(),
-        priv_key.dq(),
-        priv_key.qinv(),
-        priv_key.p_params(),
-        priv_key.q_params(),
+        GenericPrivateKeyParts::dp(priv_key),
+        GenericPrivateKeyParts::dq(priv_key),
+        GenericPrivateKeyParts::qinv(priv_key),
+        GenericPrivateKeyParts::p_params(priv_key),
+        GenericPrivateKeyParts::q_params(priv_key),
     ) {
         (Some(dp), Some(dq), Some(qinv), Some(p_params), Some(q_params)) if !is_multiprime => {
             // We have the precalculated values needed for the CRT.
 
-            let p = &priv_key.primes()[0];
-            let q = &priv_key.primes()[1];
+            let p = &GenericPrivateKeyParts::primes(priv_key)[0];
+            let q = &GenericPrivateKeyParts::primes(priv_key)[1];
 
             // precomputed: dP = (1/e) mod (p-1) = d mod (p-1)
             // precomputed: dQ = (1/e) mod (q-1) = d mod (q-1)
@@ -174,11 +177,14 @@ pub fn rsa_decrypt<R: TryCryptoRng + ?Sized>(
 /// or signature scheme. See the [module-level documentation][crate::hazmat] for more information.
 #[cfg(feature = "private-key")]
 #[inline]
-pub fn rsa_decrypt_and_check<R: TryCryptoRng + ?Sized>(
-    priv_key: &impl PrivateKeyParts<MontyParams = BoxedMontyParams>,
+pub fn rsa_decrypt_and_check<R: TryCryptoRng + ?Sized, K>(
+    priv_key: &K,
     rng: Option<&mut R>,
     c: &BoxedUint,
-) -> Result<BoxedUint> {
+) -> Result<BoxedUint>
+where
+    K: GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
+{
     let m = rsa_decrypt(rng, priv_key, c)?;
 
     // In order to defend against errors in the CRT computation, m^e is

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -86,7 +86,13 @@ where
         c.try_resize(bits).ok_or(Error::Internal)?
     };
 
-    let is_multiprime = GenericPrivateKeyParts::primes(priv_key).len() > 2;
+    // Bind once — `GenericPrivateKeyParts::primes` default returns `&[]`,
+    // so a key that overrides the CRT accessors but not `primes` could
+    // otherwise reach the CRT branch and panic on `[0]`/`[1]`. The
+    // `primes.len() >= 2` guard below makes that impossible regardless
+    // of how the trait is implemented.
+    let primes = GenericPrivateKeyParts::primes(priv_key);
+    let is_multiprime = primes.len() > 2;
 
     let m = match (
         GenericPrivateKeyParts::dp(priv_key),
@@ -95,11 +101,13 @@ where
         GenericPrivateKeyParts::p_params(priv_key),
         GenericPrivateKeyParts::q_params(priv_key),
     ) {
-        (Some(dp), Some(dq), Some(qinv), Some(p_params), Some(q_params)) if !is_multiprime => {
+        (Some(dp), Some(dq), Some(qinv), Some(p_params), Some(q_params))
+            if !is_multiprime && primes.len() >= 2 =>
+        {
             // We have the precalculated values needed for the CRT.
 
-            let p = &GenericPrivateKeyParts::primes(priv_key)[0];
-            let q = &GenericPrivateKeyParts::primes(priv_key)[1];
+            let p = &primes[0];
+            let q = &primes[1];
 
             // precomputed: dP = (1/e) mod (p-1) = d mod (p-1)
             // precomputed: dQ = (1/e) mod (q-1) = d mod (q-1)

--- a/src/key.rs
+++ b/src/key.rs
@@ -1135,7 +1135,7 @@ mod tests {
         let m = BoxedUint::from(42u64);
         let c = rsa_encrypt(&pub_key, &m).expect("encryption successful");
 
-        let m2 = rsa_decrypt_and_check::<ChaCha8Rng>(private_key, None, &c)
+        let m2 = rsa_decrypt_and_check::<ChaCha8Rng, _>(private_key, None, &c)
             .expect("unable to decrypt without blinding");
         assert_eq!(m, m2);
         let mut rng = ChaCha8Rng::from_seed([42; 32]);

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -52,18 +52,20 @@ pub trait PublicKeyParts<T: UnsignedModularInt> {
 /// Generic components of an RSA private key — minimal trait for the
 /// heapless / wip-private-key port.
 ///
-/// Mirrors [`PublicKeyParts`] in shape: generic over both the integer
-/// type `T` and the Montgomery parameter type `M`, no concrete
-/// dependency on `BoxedUint`/`BoxedMontyParams`. The minimal surface
-/// is `d()` only — CRT accessors (`dp`/`dq`/`qinv`/`p_params`/`q_params`)
-/// are deliberately omitted from this trait; they'll arrive on a
-/// future `GenericCrtPrivateKeyParts` extension trait when CT modular
-/// inverse lands upstream and we can support CRT on the heapless path.
+/// Mirrors [`PublicKeyParts`] in shape: generic over the integer
+/// type `T`, no concrete dependency on `BoxedUint`/`BoxedMontyParams`.
+/// The base surface is `d()`; the CRT accessors (`dp`/`dq`/`qinv`/
+/// `p_params`/`q_params`) are gated on `feature = "private-key"` so
+/// they only exist on the alloc path — heapless callers physically
+/// can't reach them. Default impls return `None` so a generic key
+/// without precomputed CRT values (e.g. [`GenericRsaPrivateKey`])
+/// satisfies the trait with the minimum.
 ///
 /// The legacy [`PrivateKeyParts`] (alloc-bound, `BoxedUint`-concrete)
 /// is bridged to this trait via a blanket impl, so any existing
 /// `K: PrivateKeyParts` value also satisfies
-/// `GenericPrivateKeyParts<BoxedUint, BoxedMontyParams>`.
+/// `GenericPrivateKeyParts<BoxedUint>` — with the bridge forwarding
+/// the CRT accessors when present.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub trait GenericPrivateKeyParts<T>: PublicKeyParts<T>
 where
@@ -71,6 +73,44 @@ where
 {
     /// Returns the private exponent of the key.
     fn d(&self) -> &T;
+
+    /// Returns the prime factors of the modulus. Returns `&[]` for keys
+    /// that don't store factors (the heapless default).
+    #[cfg(feature = "private-key")]
+    fn primes(&self) -> &[T] {
+        &[]
+    }
+
+    /// Returns the precomputed `dp = d mod (p - 1)` value, if available.
+    /// `None` for keys that didn't precompute CRT (the heapless default).
+    #[cfg(feature = "private-key")]
+    fn dp(&self) -> Option<&T> {
+        None
+    }
+
+    /// Returns the precomputed `dq = d mod (q - 1)` value, if available.
+    #[cfg(feature = "private-key")]
+    fn dq(&self) -> Option<&T> {
+        None
+    }
+
+    /// Returns the precomputed `qinv = q^-1 mod p` value, if available.
+    #[cfg(feature = "private-key")]
+    fn qinv(&self) -> Option<&<Self::MontyParams as ModulusParams>::MontgomeryForm> {
+        None
+    }
+
+    /// Returns the Montgomery parameters for `p`, if available.
+    #[cfg(feature = "private-key")]
+    fn p_params(&self) -> Option<&Self::MontyParams> {
+        None
+    }
+
+    /// Returns the Montgomery parameters for `q`, if available.
+    #[cfg(feature = "private-key")]
+    fn q_params(&self) -> Option<&Self::MontyParams> {
+        None
+    }
 }
 
 /// Bridge: every legacy [`PrivateKeyParts`] impl also satisfies the
@@ -78,13 +118,39 @@ where
 /// existing alloc-side consumers (and the upstream
 /// `algorithms::rsa::rsa_decrypt[_and_check]` path) be re-bound on
 /// `GenericPrivateKeyParts` incrementally without breaking compilation.
+/// Forwards the CRT accessors so the alloc-side CRT branch can run
+/// purely against the generic trait surface.
 #[cfg(feature = "private-key")]
 impl<K> GenericPrivateKeyParts<BoxedUint> for K
 where
-    K: PrivateKeyParts,
+    K: PrivateKeyParts + PublicKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
 {
     fn d(&self) -> &BoxedUint {
         PrivateKeyParts::d(self)
+    }
+
+    fn primes(&self) -> &[BoxedUint] {
+        PrivateKeyParts::primes(self)
+    }
+
+    fn dp(&self) -> Option<&BoxedUint> {
+        PrivateKeyParts::dp(self)
+    }
+
+    fn dq(&self) -> Option<&BoxedUint> {
+        PrivateKeyParts::dq(self)
+    }
+
+    fn qinv(&self) -> Option<&BoxedMontyForm> {
+        PrivateKeyParts::qinv(self)
+    }
+
+    fn p_params(&self) -> Option<&BoxedMontyParams> {
+        PrivateKeyParts::p_params(self)
+    }
+
+    fn q_params(&self) -> Option<&BoxedMontyParams> {
+        PrivateKeyParts::q_params(self)
     }
 }
 


### PR DESCRIPTION
## Summary

First real fold step in the shadow-trait migration. Re-binds the alloc-side \`algorithms::rsa::rsa_decrypt[_and_check]\` from the legacy \`PrivateKeyParts\` trait onto the new generic \`GenericPrivateKeyParts<BoxedUint>\`. Same behavior — the bridge blanket impl forwards every method to the legacy trait — but now the algorithm code talks to the same trait the heapless wrappers will eventually consume. **No more parallel trait surfaces at the algorithm boundary.**

## What changes

1. **\`GenericPrivateKeyParts<T>\` grows cfg-gated CRT accessors** with default impls returning \`None\`/\`&[]\`: \`primes()\`, \`dp()\`, \`dq()\`, \`qinv()\`, \`p_params()\`, \`q_params()\`. All gated on \`feature = "private-key"\` so heapless callers can't even see them. Default impls mean heapless value types satisfy the trait with zero extra code.

2. **Bridge \`impl<K: PrivateKeyParts> GenericPrivateKeyParts<BoxedUint>\` forwards every CRT accessor** to the legacy methods. Constraint tightened to require \`MontyParams = BoxedMontyParams\` since the legacy trait's \`qinv()\`/\`p_params()\`/\`q_params()\` are typed against the concrete Montgomery types.

3. **\`rsa_decrypt<R, K>\` and \`rsa_decrypt_and_check<R, K>\` bounds transition** from \`impl PrivateKeyParts<MontyParams = BoxedMontyParams>\` to \`K: GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>\`. Body call sites use \`GenericPrivateKeyParts::dp(priv_key)\` etc. via the trait path. \`PrivateKeyParts\` import removed from the algorithm module — the trait is no longer referenced anywhere outside its own definition and the bridge.

One existing test (\`key.rs::tests::test_decrypt\`) needed the explicit-generic call site updated from \`::<ChaCha8Rng>\` to \`::<ChaCha8Rng, _>\` for the new \`K\` type parameter.

## What this enables

- **Fold-2** can have the heapless \`GenericSigningKey<D, T, M>\` wrappers call this same algorithm-layer function via cfg-gated dispatch.
- Eventually deprecate \`PrivateKeyParts\` once nothing depends on it externally, rename \`GenericPrivateKeyParts\` back to claim the name.

## What this PR explicitly does NOT do

- **Generalize \`rsa_decrypt[_and_check]\` over \`T\`.** The body still uses BoxedUint-specific ops (\`ConcatenatingMul\`, \`as_nz_ref\`, etc.) that aren't on \`UnsignedModularInt\`. Generalizing requires widening that trait surface — substantial follow-up work.
- **Collapse \`pkcs1v15::SigningKey<D>\` / \`pss::SigningKey<D>\` into type aliases** of the generic wrappers. That's Fold-2.

## Verified

- \`cargo test --lib\` — 96/96 passing (unchanged count).
- \`cargo test --lib --no-default-features --features modmath,wip-private-key\` — 20 tests pass (unchanged).
- \`cargo check\` (default), \`--no-default-features\`, \`--no-default-features --features modmath\`, \`--no-default-features --features modmath,wip-private-key\` — all green.
- \`cargo clippy --all -- -D warnings\` + \`cargo fmt --check\` — clean.

## Scope

Net: +98/−26 across three files. Trait extension + bridge forwarding + algorithm bound transition. No behavior change. No parallel additions.

## Summary by Sourcery

Align alloc-side RSA decryption paths with the generic private key trait surface while preserving existing behavior.

Enhancements:
- Extend GenericPrivateKeyParts with cfg-gated CRT accessors and default implementations for non-CRT keys.
- Bridge legacy PrivateKeyParts implementations to GenericPrivateKeyParts<BoxedUint> including CRT-related methods.
- Rebind alloc-side RSA decryption algorithms to depend on GenericPrivateKeyParts<BoxedUint> instead of PrivateKeyParts.

Tests:
- Adjust rsa_decrypt_and_check test to specify the new private-key type parameter.