### PR TITLE
Fold-2a: GenericRsaPrivateKey grows alloc-side storage shape

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -135,9 +135,11 @@ where
 }
 
 // Manual Clone impl — `#[derive(Clone)]` doesn't synthesize the
-// `M::MontgomeryForm: Clone` bound required by the (cfg-gated)
-// `precomputed: Option<PrecomputedValues<T, M>>` field.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+// `M::MontgomeryForm: Clone` is only needed when the `precomputed`
+// field is present (private-key feature on). Heapless backends whose
+// `MontgomeryForm` doesn't impl `Clone` can still use the wip-private-key
+// build path — keep the extra bound off that variant.
+#[cfg(feature = "private-key")]
 impl<T, M> Clone for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize + Clone,
@@ -148,10 +150,24 @@ where
         Self {
             pubkey_components: self.pubkey_components.clone(),
             d: self.d.clone(),
+            primes: self.primes.clone(),
+            precomputed: self.precomputed.clone(),
+        }
+    }
+}
+
+#[cfg(all(feature = "wip-private-key", not(feature = "private-key")))]
+impl<T, M> Clone for GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize + Clone,
+    M: ModulusParams<Modulus = T> + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            pubkey_components: self.pubkey_components.clone(),
+            d: self.d.clone(),
             #[cfg(feature = "alloc")]
             primes: self.primes.clone(),
-            #[cfg(feature = "private-key")]
-            precomputed: self.precomputed.clone(),
         }
     }
 }
@@ -186,9 +202,10 @@ where
     /// Construct from the components of a precomputed key. Caller is
     /// responsible for the cryptographic relationship between `n`, `e`,
     /// and `d` (typically `e * d ≡ 1 mod λ(n)`); no validation is
-    /// performed here. No CRT precompute is attached — call
-    /// [`with_primes`](Self::with_primes) or the alloc-side
-    /// constructors to add primes / CRT acceleration.
+    /// performed here. No CRT precompute is attached — use the
+    /// alloc-side constructors on `RsaPrivateKey` to add primes and
+    /// CRT acceleration. A future `with_primes`-style constructor on
+    /// the generic type will land in Fold-2b.
     pub fn from_components(pubkey_components: GenericRsaPublicKey<T, M>, d: T) -> Self {
         Self {
             pubkey_components,
@@ -237,7 +254,10 @@ where
         &self.d
     }
 
-    #[cfg(feature = "private-key")]
+    // Gate matches the `primes` field (which is `cfg(feature = "alloc")`).
+    // `private-key` implies `alloc` today, but be explicit so this stays
+    // consistent if the implication ever loosens.
+    #[cfg(all(feature = "private-key", feature = "alloc"))]
     fn primes(&self) -> &[T] {
         &self.primes
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -112,7 +112,6 @@ where
 /// extension trait when the dependency stack provides CT modular
 /// inverse — see the roadmap in `CLAUDE.md`.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-#[derive(Clone)]
 pub struct GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -122,6 +121,39 @@ where
     pubkey_components: GenericRsaPublicKey<T, M>,
     /// Private exponent.
     d: T,
+    /// Prime factors of N (≥ 2 elements when populated). Empty `Vec`
+    /// when constructed without primes — the heapless raw-`(n, e, d)`
+    /// path. Alloc-gated because `Vec` itself requires alloc; heapless
+    /// builds don't store primes.
+    #[cfg(feature = "alloc")]
+    pub(crate) primes: alloc::vec::Vec<T>,
+    /// Precomputed CRT values, when available. Populated by
+    /// alloc-side constructors that do the CRT precompute; left
+    /// `None` by heapless / raw constructors.
+    #[cfg(feature = "private-key")]
+    pub(crate) precomputed: Option<PrecomputedValues<T, M>>,
+}
+
+// Manual Clone impl — `#[derive(Clone)]` doesn't synthesize the
+// `M::MontgomeryForm: Clone` bound required by the (cfg-gated)
+// `precomputed: Option<PrecomputedValues<T, M>>` field.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> Clone for GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize + Clone,
+    M: ModulusParams<Modulus = T> + Clone,
+    M::MontgomeryForm: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            pubkey_components: self.pubkey_components.clone(),
+            d: self.d.clone(),
+            #[cfg(feature = "alloc")]
+            primes: self.primes.clone(),
+            #[cfg(feature = "private-key")]
+            precomputed: self.precomputed.clone(),
+        }
+    }
 }
 
 // Manual `Debug` impl — never print `d`. Mirrors the redaction in the
@@ -154,11 +186,17 @@ where
     /// Construct from the components of a precomputed key. Caller is
     /// responsible for the cryptographic relationship between `n`, `e`,
     /// and `d` (typically `e * d ≡ 1 mod λ(n)`); no validation is
-    /// performed here.
+    /// performed here. No CRT precompute is attached — call
+    /// [`with_primes`](Self::with_primes) or the alloc-side
+    /// constructors to add primes / CRT acceleration.
     pub fn from_components(pubkey_components: GenericRsaPublicKey<T, M>, d: T) -> Self {
         Self {
             pubkey_components,
             d,
+            #[cfg(feature = "alloc")]
+            primes: alloc::vec::Vec::new(),
+            #[cfg(feature = "private-key")]
+            precomputed: None,
         }
     }
 
@@ -198,6 +236,36 @@ where
     fn d(&self) -> &T {
         &self.d
     }
+
+    #[cfg(feature = "private-key")]
+    fn primes(&self) -> &[T] {
+        &self.primes
+    }
+
+    #[cfg(feature = "private-key")]
+    fn dp(&self) -> Option<&T> {
+        self.precomputed.as_ref().map(|p| &p.dp)
+    }
+
+    #[cfg(feature = "private-key")]
+    fn dq(&self) -> Option<&T> {
+        self.precomputed.as_ref().map(|p| &p.dq)
+    }
+
+    #[cfg(feature = "private-key")]
+    fn qinv(&self) -> Option<&<Self::MontyParams as ModulusParams>::MontgomeryForm> {
+        self.precomputed.as_ref().map(|p| &p.qinv)
+    }
+
+    #[cfg(feature = "private-key")]
+    fn p_params(&self) -> Option<&Self::MontyParams> {
+        self.precomputed.as_ref().map(|p| &p.p_params)
+    }
+
+    #[cfg(feature = "private-key")]
+    fn q_params(&self) -> Option<&Self::MontyParams> {
+        self.precomputed.as_ref().map(|p| &p.q_params)
+    }
 }
 
 // Canonical `Zeroize` shape: impl on the type, `Drop` delegates so
@@ -212,6 +280,10 @@ where
 {
     fn zeroize(&mut self) {
         self.d.zeroize();
+        #[cfg(feature = "alloc")]
+        self.primes.zeroize();
+        #[cfg(feature = "private-key")]
+        self.precomputed.zeroize();
     }
 }
 
@@ -245,7 +317,7 @@ pub struct RsaPrivateKey {
     /// Prime factors of N, contains >= 2 elements.
     pub(crate) primes: Vec<BoxedUint>,
     /// Precomputed values to speed up private operations
-    pub(crate) precomputed: Option<PrecomputedValues>,
+    pub(crate) precomputed: Option<PrecomputedValues<BoxedUint, BoxedMontyParams>>,
 }
 
 #[cfg(feature = "private-key")]
@@ -306,26 +378,59 @@ impl Drop for RsaPrivateKey {
 impl ZeroizeOnDrop for RsaPrivateKey {}
 
 #[cfg(feature = "private-key")]
-#[derive(Clone)]
-pub(crate) struct PrecomputedValues {
+pub(crate) struct PrecomputedValues<T, M>
+where
+    T: UnsignedModularInt,
+    M: ModulusParams<Modulus = T>,
+{
     /// D mod (P-1)
-    pub(crate) dp: BoxedUint,
+    pub(crate) dp: T,
     /// D mod (Q-1)
-    pub(crate) dq: BoxedUint,
+    pub(crate) dq: T,
     /// Q^-1 mod P
-    pub(crate) qinv: BoxedMontyForm,
+    pub(crate) qinv: M::MontgomeryForm,
 
     /// Montgomery params for `p`
-    pub(crate) p_params: BoxedMontyParams,
+    pub(crate) p_params: M,
     /// Montgomery params for `q`
-    pub(crate) q_params: BoxedMontyParams,
+    pub(crate) q_params: M,
+}
+
+// Manual Clone impl — `#[derive(Clone)]` doesn't synthesize the
+// `M::MontgomeryForm: Clone` bound, only `T: Clone` and `M: Clone`.
+// We need the associated-type bound explicit.
+#[cfg(feature = "private-key")]
+impl<T, M> Clone for PrecomputedValues<T, M>
+where
+    T: UnsignedModularInt + Clone,
+    M: ModulusParams<Modulus = T> + Clone,
+    M::MontgomeryForm: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            dp: self.dp.clone(),
+            dq: self.dq.clone(),
+            qinv: self.qinv.clone(),
+            p_params: self.p_params.clone(),
+            q_params: self.q_params.clone(),
+        }
+    }
 }
 
 #[cfg(feature = "private-key")]
-impl ZeroizeOnDrop for PrecomputedValues {}
+impl<T, M> ZeroizeOnDrop for PrecomputedValues<T, M>
+where
+    T: UnsignedModularInt,
+    M: ModulusParams<Modulus = T>,
+{
+}
 
 #[cfg(feature = "private-key")]
-impl Zeroize for PrecomputedValues {
+impl<T, M> Zeroize for PrecomputedValues<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
     fn zeroize(&mut self) {
         self.dp.zeroize();
         self.dq.zeroize();
@@ -336,7 +441,11 @@ impl Zeroize for PrecomputedValues {
 }
 
 #[cfg(feature = "private-key")]
-impl Drop for PrecomputedValues {
+impl<T, M> Drop for PrecomputedValues<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
     fn drop(&mut self) {
         self.zeroize();
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -454,16 +454,25 @@ where
     fn zeroize(&mut self) {
         self.dp.zeroize();
         self.dq.zeroize();
-        // TODO: once these have landed in crypto-bigint
+        // KNOWN GAP: `qinv` (M::MontgomeryForm), `p_params` / `q_params`
+        // (M) are not wiped because the trait doesn't require them to
+        // impl `Zeroize`, and upstream `BoxedMontyForm` /
+        // `BoxedMontyParams` don't yet. Re-enable once the dep stack
+        // does:
+        // self.qinv.zeroize();
         // self.p_params.zeroize();
         // self.q_params.zeroize();
     }
 }
 
+// `Drop` impl bounds must match the struct's exactly (Rust drop-check
+// rule). `T: UnsignedModularInt` already implies `T: Zeroize` via the
+// `FixedWidthUnsignedInt` supertrait, so the body's `self.zeroize()`
+// call resolves without an explicit `Zeroize` bound here.
 #[cfg(feature = "private-key")]
 impl<T, M> Drop for PrecomputedValues<T, M>
 where
-    T: UnsignedModularInt + Zeroize,
+    T: UnsignedModularInt,
     M: ModulusParams<Modulus = T>,
 {
     fn drop(&mut self) {

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -30,7 +30,6 @@ use zeroize::Zeroize;
 /// Generic over the digest `D`, integer type `T`, and Montgomery parameters
 /// `M`. Holds a [`GenericRsaPrivateKey<T, M>`] plus the precomputed
 /// DigestInfo prefix for `D`.
-#[derive(Clone)]
 pub struct GenericSigningKey<D, T, M>
 where
     D: Digest,
@@ -43,6 +42,24 @@ where
     #[cfg(not(feature = "alloc"))]
     pub(super) prefix: Prefix,
     pub(super) phantom: PhantomData<D>,
+}
+
+// Manual Clone impl — `M::MontgomeryForm: Clone` bound from
+// `GenericRsaPrivateKey<T, M>` isn't synthesized by `#[derive]`.
+impl<D, T, M> Clone for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize + Clone,
+    M: ModulusParams<Modulus = T> + Clone,
+    M::MontgomeryForm: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            prefix: self.prefix.clone(),
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<D, T, M> GenericSigningKey<D, T, M>

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -44,14 +44,33 @@ where
     pub(super) phantom: PhantomData<D>,
 }
 
-// Manual Clone impl — `M::MontgomeryForm: Clone` bound from
-// `GenericRsaPrivateKey<T, M>` isn't synthesized by `#[derive]`.
+// Manual Clone impls — split by `private-key` cfg to avoid imposing
+// the `M::MontgomeryForm: Clone` bound on heapless backends where it
+// isn't needed (only `GenericRsaPrivateKey`'s `precomputed` field
+// requires it, and that field is `cfg(private-key)`).
+#[cfg(feature = "private-key")]
 impl<D, T, M> Clone for GenericSigningKey<D, T, M>
 where
     D: Digest,
     T: UnsignedModularInt + Zeroize + Clone,
     M: ModulusParams<Modulus = T> + Clone,
     M::MontgomeryForm: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            prefix: self.prefix.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[cfg(not(feature = "private-key"))]
+impl<D, T, M> Clone for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize + Clone,
+    M: ModulusParams<Modulus = T> + Clone,
 {
     fn clone(&self) -> Self {
         Self {

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -31,7 +31,6 @@ use zeroize::Zeroize;
 ///
 /// PSS has no DigestInfo prefix — `D` is purely a phantom marker for the
 /// digest algorithm used by both encode and verify.
-#[derive(Clone)]
 pub struct GenericSigningKey<D, T, M>
 where
     D: Digest,
@@ -41,6 +40,24 @@ where
     pub(super) inner: GenericRsaPrivateKey<T, M>,
     pub(super) salt_len: usize,
     pub(super) phantom: PhantomData<D>,
+}
+
+// Manual Clone impl — `M::MontgomeryForm: Clone` bound from
+// `GenericRsaPrivateKey<T, M>` isn't synthesized by `#[derive]`.
+impl<D, T, M> Clone for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize + Clone,
+    M: ModulusParams<Modulus = T> + Clone,
+    M::MontgomeryForm: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            salt_len: self.salt_len,
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<D, T, M> GenericSigningKey<D, T, M>

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -42,14 +42,33 @@ where
     pub(super) phantom: PhantomData<D>,
 }
 
-// Manual Clone impl — `M::MontgomeryForm: Clone` bound from
-// `GenericRsaPrivateKey<T, M>` isn't synthesized by `#[derive]`.
+// Manual Clone impls — split by `private-key` cfg to avoid imposing
+// the `M::MontgomeryForm: Clone` bound on heapless backends where it
+// isn't needed (only `GenericRsaPrivateKey`'s `precomputed` field
+// requires it, and that field is `cfg(private-key)`).
+#[cfg(feature = "private-key")]
 impl<D, T, M> Clone for GenericSigningKey<D, T, M>
 where
     D: Digest,
     T: UnsignedModularInt + Zeroize + Clone,
     M: ModulusParams<Modulus = T> + Clone,
     M::MontgomeryForm: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            salt_len: self.salt_len,
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[cfg(not(feature = "private-key"))]
+impl<D, T, M> Clone for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize + Clone,
+    M: ModulusParams<Modulus = T> + Clone,
 {
     fn clone(&self) -> Self {
         Self {


### PR DESCRIPTION
## Summary

First sub-step of Fold-2 (the storage-merge fold following the \`RsaPublicKey = GenericRsaPublicKey<BoxedUint, BoxedMontyParams>\` pattern). Brings \`GenericRsaPrivateKey<T, M>\`'s storage shape to parity with \`RsaPrivateKey\` so the next sub-PR can swap \`RsaPrivateKey\` to a type alias.

## What changes

1. **\`PrecomputedValues\` is now generic \`PrecomputedValues<T, M>\`.** \`RsaPrivateKey::precomputed\` now holds \`Option<PrecomputedValues<BoxedUint, BoxedMontyParams>>\` — same concrete type at the type-alias substitution we'll claim in 2b. \`#[derive(Clone)]\` replaced with a manual impl since the derive doesn't synthesize the \`M::MontgomeryForm: Clone\` bound the \`qinv\` field needs.

2. **\`GenericRsaPrivateKey<T, M>\` grows two cfg-gated fields:**
   - \`#[cfg(feature = "alloc")] primes: Vec<T>\` — empty \`Vec\` when constructed via the heapless raw path; populated by alloc-side constructors (Fold-2b).
   - \`#[cfg(feature = "private-key")] precomputed: Option<PrecomputedValues<T, M>>\` — \`None\` for keys without CRT precompute.

   \`from_components\` initializes both to "empty/none" so the existing minimal \`(n, e, d)\` heapless construction still works verbatim. Manual \`Clone\` impl for the same \`M::MontgomeryForm\` reason. \`Zeroize\` extended to wipe both new fields.

3. **\`GenericPrivateKeyParts<T>\` impl on \`GenericRsaPrivateKey<T, M>\` forwards the CRT accessors** to the stored fields (cfg-gated on \`private-key\`, matching the trait method gating from PR #27).

Downstream \`GenericSigningKey<D, T, M>\` types (both pkcs1v15 and pss) had to lose their \`#[derive(Clone)]\` and grow manual impls for the same \`M::MontgomeryForm: Clone\` reason — their \`inner: GenericRsaPrivateKey<T, M>\` field now propagates that requirement.

## Verified

- \`cargo test --lib\` — 96/96 passing (count unchanged — no new tests; pure structural refactor).
- \`cargo test --lib --no-default-features --features modmath,wip-private-key\` — 20 passing.
- \`cargo check\` across all four feature combinations — green.
- \`cargo clippy --all -- -D warnings\` + \`cargo fmt --check\` — clean.

No behavior change for existing alloc users (\`RsaPrivateKey\` is unchanged in shape and trait surface).

## Coming next (Fold-2b)

- Replace \`pub struct RsaPrivateKey\` with \`pub type RsaPrivateKey = GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>\`.
- Move all \`impl RsaPrivateKey {...}\` blocks to \`impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {...}\`.
- Drop the bridge — \`RsaPrivateKey\` will impl \`GenericPrivateKeyParts<BoxedUint>\` directly via the generic.

Net: +158/−15 across three files.

## Summary by Sourcery

Align GenericRsaPrivateKey’s storage and CRT accessors with RsaPrivateKey to prepare for making RsaPrivateKey a type alias over the generic type.

Enhancements:
- Extend GenericRsaPrivateKey to store alloc-gated prime factors and optional CRT precomputed data behind feature flags while keeping heapless construction unchanged.
- Make PrecomputedValues generic over integer and modulus parameter types and wire it into RsaPrivateKey’s precomputed field.
- Forward GenericPrivateKeyParts CRT-related accessors from GenericRsaPrivateKey to its stored primes and precomputed values under the private-key feature.
- Replace derive-based Clone implementations with manual Clone impls that add the required M::MontgomeryForm: Clone bound for GenericRsaPrivateKey, PrecomputedValues, and generic signing key types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when copying RSA signing and private key types across supported configurations.
  * Expanded cleanup of sensitive key material so more stored secret values are wiped when no longer needed.
  * Fixed handling of RSA private key components so additional precomputed values are preserved and available where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->