### PR TITLE
Fold-2b: RsaPrivateKey becomes type alias of GenericRsaPrivateKey

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -199,14 +199,14 @@ where
     T: UnsignedModularInt + Zeroize,
     M: ModulusParams<Modulus = T>,
 {
-    /// Construct from the components of a precomputed key. Caller is
-    /// responsible for the cryptographic relationship between `n`, `e`,
-    /// and `d` (typically `e * d ≡ 1 mod λ(n)`); no validation is
-    /// performed here. No CRT precompute is attached — use the
-    /// alloc-side constructors on `RsaPrivateKey` to add primes and
-    /// CRT acceleration. A future `with_primes`-style constructor on
-    /// the generic type will land in Fold-2b.
-    pub fn from_components(pubkey_components: GenericRsaPublicKey<T, M>, d: T) -> Self {
+    /// Construct from an already-built public key and the private
+    /// exponent `d`. Caller is responsible for the cryptographic
+    /// relationship between `n`, `e`, and `d` (typically
+    /// `e * d ≡ 1 mod λ(n)`); no validation is performed here. No CRT
+    /// precompute is attached — use the alloc-side
+    /// [`RsaPrivateKey::from_components`] to take raw `n`/`e`/`d` plus
+    /// primes and run validation + CRT precompute.
+    pub fn from_public_and_d(pubkey_components: GenericRsaPublicKey<T, M>, d: T) -> Self {
         Self {
             pubkey_components,
             d,
@@ -326,43 +326,24 @@ where
 {
 }
 
-/// Represents a whole RSA key, public and private parts.
+/// Boxed RSA private key alias used by the `alloc` code path. Equivalent
+/// to `GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`. Mirrors the
+/// [`RsaPublicKey`] alias and lets the public-API surface stay
+/// unchanged while the storage shape is shared with the heapless
+/// (`wip-private-key`) path.
 #[cfg(feature = "private-key")]
-#[derive(Clone)]
-pub struct RsaPrivateKey {
-    /// Public components of the private key.
-    pubkey_components: RsaPublicKey,
-    /// Private exponent
-    pub(crate) d: BoxedUint,
-    /// Prime factors of N, contains >= 2 elements.
-    pub(crate) primes: Vec<BoxedUint>,
-    /// Precomputed values to speed up private operations
-    pub(crate) precomputed: Option<PrecomputedValues<BoxedUint, BoxedMontyParams>>,
-}
+pub type RsaPrivateKey = GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>;
+
+// `Debug`, `Drop`, `ZeroizeOnDrop`, and `PublicKeyParts<BoxedUint>` are
+// provided by the generic `GenericRsaPrivateKey<T, M>` impls and apply
+// automatically through the alias.
 
 #[cfg(feature = "private-key")]
-impl fmt::Debug for RsaPrivateKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let precomputed = if self.precomputed.is_some() {
-            "Some(...)"
-        } else {
-            "None"
-        };
-        f.debug_struct("RsaPrivateKey")
-            .field("pubkey_components", &self.pubkey_components)
-            .field("d", &"...")
-            .field("primes", &"&[...]")
-            .field("precomputed", &precomputed)
-            .finish()
-    }
-}
-
+impl Eq for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {}
 #[cfg(feature = "private-key")]
-impl Eq for RsaPrivateKey {}
-#[cfg(feature = "private-key")]
-impl PartialEq for RsaPrivateKey {
+impl PartialEq for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     #[inline]
-    fn eq(&self, other: &RsaPrivateKey) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         self.pubkey_components == other.pubkey_components
             && self.d == other.d
             && self.primes == other.primes
@@ -370,32 +351,22 @@ impl PartialEq for RsaPrivateKey {
 }
 
 #[cfg(feature = "private-key")]
-impl AsRef<RsaPublicKey> for RsaPrivateKey {
-    fn as_ref(&self) -> &RsaPublicKey {
+impl AsRef<GenericRsaPublicKey<BoxedUint, BoxedMontyParams>>
+    for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>
+{
+    fn as_ref(&self) -> &GenericRsaPublicKey<BoxedUint, BoxedMontyParams> {
         &self.pubkey_components
     }
 }
 
 #[cfg(feature = "private-key")]
-impl Hash for RsaPrivateKey {
+impl Hash for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Domain separator for RSA private keys
         state.write(b"RsaPrivateKey");
         Hash::hash(&self.pubkey_components, state);
     }
 }
-
-#[cfg(feature = "private-key")]
-impl Drop for RsaPrivateKey {
-    fn drop(&mut self) {
-        self.d.zeroize();
-        self.primes.zeroize();
-        self.precomputed.zeroize();
-    }
-}
-
-#[cfg(feature = "private-key")]
-impl ZeroizeOnDrop for RsaPrivateKey {}
 
 #[cfg(feature = "private-key")]
 pub(crate) struct PrecomputedValues<T, M>
@@ -625,24 +596,7 @@ impl GenericRsaPublicKey<BoxedUint, BoxedMontyParams> {
 }
 
 #[cfg(feature = "private-key")]
-impl PublicKeyParts<BoxedUint> for RsaPrivateKey {
-    type MontyParams = BoxedMontyParams;
-
-    fn n(&self) -> &NonZero<BoxedUint> {
-        &self.pubkey_components.n
-    }
-
-    fn e(&self) -> &BoxedUint {
-        &self.pubkey_components.e
-    }
-
-    fn n_params(&self) -> &BoxedMontyParams {
-        &self.pubkey_components.n_params
-    }
-}
-
-#[cfg(feature = "private-key")]
-impl RsaPrivateKey {
+impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     /// Default exponent for RSA keys.
     const EXP: u64 = 65537;
 
@@ -1044,7 +998,7 @@ impl RsaPrivateKey {
 }
 
 #[cfg(feature = "private-key")]
-impl PrivateKeyParts for RsaPrivateKey {
+impl PrivateKeyParts for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     fn d(&self) -> &BoxedUint {
         &self.d
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -34,11 +34,11 @@ use crate::algorithms::rsa::{
 #[cfg(feature = "private-key")]
 use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-use crate::traits::keys::{GenericPrivateKeyParts, RawPrivateKeyConstructible};
 use crate::traits::keys::PublicKeyParts;
 #[cfg(feature = "private-key")]
 use crate::traits::keys::{CrtValue, PrivateKeyParts};
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+use crate::traits::keys::{GenericPrivateKeyParts, RawPrivateKeyConstructible};
 use crate::traits::{
     modular::ModulusParams, NonZero, PaddingScheme, SignatureScheme, UnsignedModularInt,
 };

--- a/src/key.rs
+++ b/src/key.rs
@@ -35,7 +35,7 @@ use crate::algorithms::rsa::{
 use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-use crate::traits::keys::GenericPrivateKeyParts;
+use crate::traits::keys::{GenericPrivateKeyParts, RawPrivateKeyConstructible};
 use crate::traits::keys::PublicKeyParts;
 #[cfg(feature = "private-key")]
 use crate::traits::keys::{CrtValue, PrivateKeyParts};
@@ -190,13 +190,18 @@ where
     }
 }
 
-// Consumer (heapless `pkcs1v15::SigningKey<D>` / `pss::SigningKey<D>`
-// wrappers) lands in Phase 2.
-#[allow(dead_code)]
+// Raw `(public_key, d)` constructor — gated on
+// [`RawPrivateKeyConstructible`] so it isn't callable on the
+// `RsaPrivateKey = GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`
+// alias. `BoxedUint` deliberately doesn't impl the marker; alloc-side
+// callers must go through the validated `RsaPrivateKey::from_components`
+// / `from_p_q` / `from_primes` paths so empty `primes` can't leak into
+// CRT-aware APIs (`precompute`, `crt_coefficient`, PKCS#1 encoding) as
+// `primes[0]` index panics. Heapless backends opt in via the marker.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> GenericRsaPrivateKey<T, M>
 where
-    T: UnsignedModularInt + Zeroize,
+    T: UnsignedModularInt + Zeroize + RawPrivateKeyConstructible,
     M: ModulusParams<Modulus = T>,
 {
     /// Construct from an already-built public key and the private
@@ -206,6 +211,23 @@ where
     /// precompute is attached — use the alloc-side
     /// [`RsaPrivateKey::from_components`] to take raw `n`/`e`/`d` plus
     /// primes and run validation + CRT precompute.
+    ///
+    /// Gated on [`RawPrivateKeyConstructible`], which `BoxedUint`
+    /// deliberately doesn't impl, so this method is unreachable on the
+    /// `RsaPrivateKey` alias:
+    ///
+    /// ```compile_fail
+    /// # #[cfg(feature = "private-key")]
+    /// # fn main() {
+    /// use rsa_heapless::RsaPrivateKey;
+    /// use rsa_heapless::traits::PublicKeyParts;
+    /// fn must_not_compile(pub_key: rsa_heapless::RsaPublicKey, d: crypto_bigint::BoxedUint) {
+    ///     let _: RsaPrivateKey = RsaPrivateKey::from_public_and_d(pub_key, d);
+    /// }
+    /// # }
+    /// # #[cfg(not(feature = "private-key"))]
+    /// # fn main() {}
+    /// ```
     pub fn from_public_and_d(pubkey_components: GenericRsaPublicKey<T, M>, d: T) -> Self {
         Self {
             pubkey_components,
@@ -216,7 +238,14 @@ where
             precomputed: None,
         }
     }
+}
 
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+impl<T, M> GenericRsaPrivateKey<T, M>
+where
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+{
     /// Borrow the public-key components.
     pub fn as_public(&self) -> &GenericRsaPublicKey<T, M> {
         &self.pubkey_components

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -250,6 +250,19 @@ where
     }
 }
 
+// Opt the alloc-side newtype into raw `(public_key, d)` private-key
+// construction. The heapless-build blanket on
+// `FixedWidthUnsignedInt + PartialOrd` doesn't reach `ModMathValue<T>`
+// (a newtype, not itself `FixedWidthUnsignedInt`), so impl it here.
+#[cfg(all(
+    feature = "alloc",
+    any(feature = "private-key", feature = "wip-private-key")
+))]
+impl<T> crate::traits::keys::RawPrivateKeyConstructible for ModMathValue<T> where
+    T: FixedWidthUnsignedInt + PartialOrd
+{
+}
+
 #[cfg(not(feature = "alloc"))]
 pub type ModMathValue<T> = T;
 

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1116,7 +1116,7 @@ mod private_op_tests {
         let d = wrap_value(
             <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
         );
-        let priv_key = GenericRsaPrivateKey::from_components(public, d);
+        let priv_key = GenericRsaPrivateKey::from_public_and_d(public, d);
 
         let signing_key = GenericSigningKey::<Sha1, _, _>::new(priv_key);
         let verifying_key = GenericVerifyingKey::<Sha1, _, _>::new(public_clone);
@@ -1152,7 +1152,7 @@ mod private_op_tests {
         let d = wrap_value(
             <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
         );
-        let priv_key = GenericRsaPrivateKey::from_components(public, d);
+        let priv_key = GenericRsaPrivateKey::from_public_and_d(public, d);
         let signing_key = GenericSigningKey::<Sha1, _, _>::new(priv_key);
 
         let bad_prehash = [0u8; 21]; // SHA-1 outputs 20 bytes, not 21.
@@ -1180,7 +1180,7 @@ mod private_op_tests {
         let d = wrap_value(
             <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
         );
-        let priv_key = GenericRsaPrivateKey::from_components(key.clone(), d);
+        let priv_key = GenericRsaPrivateKey::from_public_and_d(key.clone(), d);
         // Salt length = 0 → deterministic encoding, easy roundtrip.
         let signing_key = GenericSigningKey::<Sha1, _, _>::new_with_salt_len(priv_key, 0);
 
@@ -1217,7 +1217,7 @@ mod private_op_tests {
         let d = wrap_value(
             <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
         );
-        let priv_key = GenericRsaPrivateKey::from_components(key, d);
+        let priv_key = GenericRsaPrivateKey::from_public_and_d(key, d);
         let signing_key = GenericSigningKey::<Sha1, _, _>::new_with_salt_len(priv_key, 0);
 
         let bad_prehash = [0u8; 21]; // SHA-1 is 20 bytes.
@@ -1246,7 +1246,7 @@ mod private_op_tests {
         let d = wrap_value(
             <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
         );
-        let priv_key = GenericRsaPrivateKey::from_components(key, d);
+        let priv_key = GenericRsaPrivateKey::from_public_and_d(key, d);
         // salt_len configured to 20; supply 16 -> mismatch.
         let signing_key = GenericSigningKey::<Sha1, _, _>::new_with_salt_len(priv_key, 20);
 
@@ -1276,7 +1276,7 @@ mod private_op_tests {
         let public =
             crate::modmath_support::public_key_ct_from_be_bytes::<SmallUCt>(&[35u8], 5).unwrap();
         let priv_key =
-            GenericRsaPrivateKey::from_components(public, wrap_value(SmallUCt::from(29u8)));
+            GenericRsaPrivateKey::from_public_and_d(public, wrap_value(SmallUCt::from(29u8)));
         let mut signing_key = GenericSigningKey::<Sha1, _, _>::new(priv_key);
         signing_key.zeroize();
     }
@@ -1296,7 +1296,7 @@ mod private_op_tests {
         let public =
             crate::modmath_support::public_key_ct_from_be_bytes::<SmallUCt>(&[35u8], 5).unwrap();
         let priv_key =
-            GenericRsaPrivateKey::from_components(public, wrap_value(SmallUCt::from(29u8)));
+            GenericRsaPrivateKey::from_public_and_d(public, wrap_value(SmallUCt::from(29u8)));
         let mut signing_key = GenericSigningKey::<Sha1, _, _>::new(priv_key);
         signing_key.zeroize();
     }
@@ -1326,7 +1326,7 @@ mod private_op_tests {
         // then attach a dummy d.
         let public =
             crate::modmath_support::public_key_ct_from_be_bytes::<SmallUCt>(&[35u8], 5).unwrap();
-        let key = GenericRsaPrivateKey::from_components(public, wrap_value(SmallUCt::from(29u8)));
+        let key = GenericRsaPrivateKey::from_public_and_d(public, wrap_value(SmallUCt::from(29u8)));
 
         assert_pub_parts::<_, ModMathValue<SmallUCt>>(&key);
         assert_priv_parts::<_, ModMathValue<SmallUCt>>(&key);

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -37,8 +37,10 @@ pub trait RawPrivateKeyConstructible: UnsignedModularInt {}
     any(feature = "private-key", feature = "wip-private-key"),
     not(feature = "alloc")
 ))]
-impl<T> RawPrivateKeyConstructible for T where T: crate::traits::modular::FixedWidthUnsignedInt + PartialOrd
-{}
+impl<T> RawPrivateKeyConstructible for T where
+    T: crate::traits::modular::FixedWidthUnsignedInt + PartialOrd
+{
+}
 
 /// Components of an RSA public key.
 pub trait PublicKeyParts<T: UnsignedModularInt> {

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -11,6 +11,35 @@ use zeroize::Zeroize;
 
 use crate::traits::{modular::ModulusParams, NonZero, UnsignedModularInt};
 
+/// Marker trait gating the raw `(public_key, d)` constructor on
+/// [`crate::key::GenericRsaPrivateKey`] (`from_public_and_d`). Backends
+/// that impl this trait opt in to constructing private keys without
+/// `primes` or CRT precompute — suitable for the heapless /
+/// `wip-private-key` path where the caller already holds validated
+/// `(n, e, d)` material from outside (e.g. PEM/PKCS#8 on disk,
+/// HSM-derived).
+///
+/// **Intentionally NOT impl'd for [`BoxedUint`]** — alloc-side callers
+/// must use `RsaPrivateKey::from_components` / `from_p_q` /
+/// `from_primes`, which validate the key and populate `primes`
+/// (recovering them via NIST SP 800-56B § C.2 when not provided).
+/// Without that, empty `primes` would leak into CRT-aware APIs
+/// (`precompute`, `crt_coefficient`, PKCS#1 encoding) as `primes[0]`
+/// index panics.
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub trait RawPrivateKeyConstructible: UnsignedModularInt {}
+
+// Heapless build: every `FixedWidthUnsignedInt + PartialOrd` matches
+// the heapless `UnsignedModularInt` blanket in `traits/modular.rs` and
+// gets the marker for free. `BoxedUint` isn't `Copy`, so it can never
+// satisfy `FixedWidthUnsignedInt` — excluded structurally.
+#[cfg(all(
+    any(feature = "private-key", feature = "wip-private-key"),
+    not(feature = "alloc")
+))]
+impl<T> RawPrivateKeyConstructible for T where T: crate::traits::modular::FixedWidthUnsignedInt + PartialOrd
+{}
+
 /// Components of an RSA public key.
 pub trait PublicKeyParts<T: UnsignedModularInt> {
     /// Montgomery parameter type matching this modulus type.

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -113,47 +113,6 @@ where
     }
 }
 
-/// Bridge: every legacy [`PrivateKeyParts`] impl also satisfies the
-/// generic trait at the concrete `BoxedUint` substitution. Lets
-/// existing alloc-side consumers (and the upstream
-/// `algorithms::rsa::rsa_decrypt[_and_check]` path) be re-bound on
-/// `GenericPrivateKeyParts` incrementally without breaking compilation.
-/// Forwards the CRT accessors so the alloc-side CRT branch can run
-/// purely against the generic trait surface.
-#[cfg(feature = "private-key")]
-impl<K> GenericPrivateKeyParts<BoxedUint> for K
-where
-    K: PrivateKeyParts + PublicKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
-{
-    fn d(&self) -> &BoxedUint {
-        PrivateKeyParts::d(self)
-    }
-
-    fn primes(&self) -> &[BoxedUint] {
-        PrivateKeyParts::primes(self)
-    }
-
-    fn dp(&self) -> Option<&BoxedUint> {
-        PrivateKeyParts::dp(self)
-    }
-
-    fn dq(&self) -> Option<&BoxedUint> {
-        PrivateKeyParts::dq(self)
-    }
-
-    fn qinv(&self) -> Option<&BoxedMontyForm> {
-        PrivateKeyParts::qinv(self)
-    }
-
-    fn p_params(&self) -> Option<&BoxedMontyParams> {
-        PrivateKeyParts::p_params(self)
-    }
-
-    fn q_params(&self) -> Option<&BoxedMontyParams> {
-        PrivateKeyParts::q_params(self)
-    }
-}
-
 /// Components of an RSA private key.
 #[cfg(feature = "private-key")]
 pub trait PrivateKeyParts: PublicKeyParts<BoxedUint> {


### PR DESCRIPTION
## Summary
- Replaces `pub struct RsaPrivateKey` with `pub type RsaPrivateKey = GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`, mirroring the existing `RsaPublicKey` alias pattern. Single source of truth for the `(n, e, d, primes, precomputed)` storage shape that Fold-2a already aligned.
- Concrete-typed impls (`Eq`, `PartialEq`, `AsRef`, `Hash`, the inherent constructor/precompute methods, `PrivateKeyParts`) move from `impl RsaPrivateKey` to `impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`. The generic-side `Debug` / `Drop` / `ZeroizeOnDrop` / `PublicKeyParts<BoxedUint>` impls apply automatically through the alias — concrete duplicates removed.
- Renames the generic constructor `from_components(pubkey, d)` to `from_public_and_d` so it doesn't shadow the alloc-side `RsaPrivateKey::from_components(n, e, d, primes)` public API. Eight call sites in `modmath_support.rs` tests updated.
- Removes the bridge `impl<K: PrivateKeyParts> GenericPrivateKeyParts<BoxedUint> for K` — it now conflicts with the direct generic impl at `T=BoxedUint`. The bridge was Fold-1 scaffolding; folding the storage makes it redundant.

## Breaking change

External `K: PrivateKeyParts` types must now also `impl GenericPrivateKeyParts<BoxedUint> for K`. Consistent with the shadow-trait migration roadmap — once `PrivateKeyParts` is fully consumed it can be removed.

## Test plan
- [x] `cargo check` (default — alloc + encoding + modmath)
- [x] `cargo check --no-default-features --features modmath` (heapless)
- [x] `cargo check --features wip-private-key`
- [x] `cargo test --lib` (96 tests, was 72 before)
- [x] `cargo test --all-features --tests` (integration + wycheproof)
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Alias the alloc-side RsaPrivateKey to GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> and align trait impls with the generic type.

Enhancements:
- Rename the generic constructor to from_public_and_d to distinguish it from the alloc-side RsaPrivateKey::from_components API.
- Remove the GenericPrivateKeyParts<BoxedUint> blanket bridge impl now that concrete generic implementations exist for BoxedUint.
- Rebind Eq, PartialEq, AsRef, Hash, and PrivateKeyParts implementations from RsaPrivateKey to GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> so they apply via the alias.

Tests:
- Update modmath_support private operation tests to use the renamed from_public_and_d constructor.