### PR TITLE
Fold-2c: SigningKey<D> becomes type alias of GenericSigningKey

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -213,21 +213,9 @@ where
     /// primes and run validation + CRT precompute.
     ///
     /// Gated on [`RawPrivateKeyConstructible`], which `BoxedUint`
-    /// deliberately doesn't impl, so this method is unreachable on the
-    /// `RsaPrivateKey` alias:
-    ///
-    /// ```compile_fail
-    /// # #[cfg(feature = "private-key")]
-    /// # fn main() {
-    /// use rsa_heapless::RsaPrivateKey;
-    /// use rsa_heapless::traits::PublicKeyParts;
-    /// fn must_not_compile(pub_key: rsa_heapless::RsaPublicKey, d: crypto_bigint::BoxedUint) {
-    ///     let _: RsaPrivateKey = RsaPrivateKey::from_public_and_d(pub_key, d);
-    /// }
-    /// # }
-    /// # #[cfg(not(feature = "private-key"))]
-    /// # fn main() {}
-    /// ```
+    /// deliberately doesn't impl, so this method is unreachable on
+    /// the `RsaPrivateKey` alias. See that alias's docstring for a
+    /// `compile_fail` doctest that locks the behavior in.
     pub fn from_public_and_d(pubkey_components: GenericRsaPublicKey<T, M>, d: T) -> Self {
         Self {
             pubkey_components,
@@ -360,6 +348,18 @@ where
 /// [`RsaPublicKey`] alias and lets the public-API surface stay
 /// unchanged while the storage shape is shared with the heapless
 /// (`wip-private-key`) path.
+///
+/// The raw `(public_key, d)` constructor on
+/// [`GenericRsaPrivateKey::from_public_and_d`] is gated on
+/// [`RawPrivateKeyConstructible`], which `BoxedUint` deliberately
+/// doesn't impl, so it's unreachable through this alias:
+///
+/// ```compile_fail
+/// use rsa_heapless::RsaPrivateKey;
+/// fn must_not_compile(pub_key: rsa_heapless::RsaPublicKey, d: crypto_bigint::BoxedUint) {
+///     let _: RsaPrivateKey = RsaPrivateKey::from_public_and_d(pub_key, d);
+/// }
+/// ```
 #[cfg(feature = "private-key")]
 pub type RsaPrivateKey = GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>;
 

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -21,6 +21,7 @@ use crate::{
     },
 };
 use const_oid::AssociatedOid;
+use core::fmt;
 use core::marker::PhantomData;
 use digest::Digest;
 use zeroize::Zeroize;
@@ -42,6 +43,23 @@ where
     #[cfg(not(feature = "alloc"))]
     pub(super) prefix: Prefix,
     pub(super) phantom: PhantomData<D>,
+}
+
+// Manual `Debug` — `#[derive]` would synthesize unwanted bounds on
+// `D`/`T`/`M`; the inner private key already redacts `d`.
+impl<D, T, M> fmt::Debug for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+    GenericRsaPrivateKey<T, M>: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKey")
+            .field("inner", &self.inner)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
 }
 
 // Manual Clone impls — split by `private-key` cfg to avoid imposing
@@ -221,8 +239,13 @@ where
     T: UnsignedModularInt + Zeroize,
     M: ModulusParams<Modulus = T>,
 {
-    /// Derive the matching [`GenericVerifyingKey`] from this signing key.
-    pub fn verifying_key(&self) -> GenericVerifyingKey<D, T, M>
+    /// Derive the matching [`GenericVerifyingKey`] from this signing
+    /// key, regenerating the DigestInfo prefix from `D`. Not named
+    /// `verifying_key` because that would shadow
+    /// [`signature::Keypair::verifying_key`], which preserves the
+    /// signing key's existing prefix (important for unprefixed
+    /// signing keys whose verifying-side prefix must also be empty).
+    pub fn to_verifying_key(&self) -> GenericVerifyingKey<D, T, M>
     where
         GenericRsaPrivateKey<T, M>: Clone,
         crate::key::GenericRsaPublicKey<T, M>: Clone,

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -7,11 +7,11 @@
 //! the DigestInfo prefix, caller-supplied scratch buffers for the EM
 //! and signature output.
 
-use super::sign_into;
 #[cfg(feature = "alloc")]
-use super::{pkcs1v15_generate_prefix, GenericVerifyingKey};
+use super::pkcs1v15_generate_prefix;
 #[cfg(not(feature = "alloc"))]
 use super::{pkcs1v15_generate_prefix_helper, Prefix};
+use super::{sign_into, GenericVerifyingKey};
 use crate::{
     errors::Result,
     key::GenericRsaPrivateKey,
@@ -55,7 +55,7 @@ where
     GenericRsaPrivateKey<T, M>: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SigningKey")
+        f.debug_struct("GenericSigningKey")
             .field("inner", &self.inner)
             .field("prefix", &self.prefix)
             .finish()
@@ -232,24 +232,26 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<D, T, M> GenericSigningKey<D, T, M>
 where
-    D: Digest + AssociatedOid,
+    D: Digest,
     T: UnsignedModularInt + Zeroize,
     M: ModulusParams<Modulus = T>,
 {
     /// Derive the matching [`GenericVerifyingKey`] from this signing
-    /// key, regenerating the DigestInfo prefix from `D`. Not named
+    /// key, preserving the existing DigestInfo prefix (so unprefixed
+    /// signing keys yield unprefixed verifying keys). Not named
     /// `verifying_key` because that would shadow
-    /// [`signature::Keypair::verifying_key`], which preserves the
-    /// signing key's existing prefix (important for unprefixed
-    /// signing keys whose verifying-side prefix must also be empty).
+    /// [`signature::Keypair::verifying_key`] for callers using
+    /// method-call syntax.
     pub fn to_verifying_key(&self) -> GenericVerifyingKey<D, T, M>
     where
-        GenericRsaPrivateKey<T, M>: Clone,
         crate::key::GenericRsaPublicKey<T, M>: Clone,
     {
-        GenericVerifyingKey::new(self.inner.as_public().clone())
+        GenericVerifyingKey {
+            inner: self.inner.as_public().clone(),
+            prefix: self.prefix.clone(),
+            phantom: PhantomData,
+        }
     }
 }

--- a/src/pkcs1v15/signing_key.rs
+++ b/src/pkcs1v15/signing_key.rs
@@ -1,9 +1,19 @@
-use super::{pkcs1v15_generate_prefix, sign, GenericVerifyingKey, Signature, VerifyingKey};
+//! Boxed RSASSA-PKCS1-v1_5 signing key — alloc-side type alias and
+//! specializations over [`super::GenericSigningKey`]. Mirrors the
+//! pattern on the verify side (`verifying_key.rs`).
+//!
+//! The struct, generic constructors (`new`, `new_unprefixed`), `Clone`,
+//! `Debug`, `AsRef<GenericRsaPrivateKey<T, M>>`, `Zeroize`, and the
+//! `try_sign_into` family all live on [`super::GenericSigningKey`].
+//! This file holds only what's tied to the boxed substitution:
+//! keygen-bearing constructors, the `signature::*Signer` trait
+//! family (which delegates to the alloc-side `sign(...)`), encoding,
+//! serde, and the legacy `Keypair` wiring.
+
+use super::{sign, GenericSigningKey, GenericVerifyingKey, Signature, VerifyingKey};
 use crate::{dummy_rng::DummyRng, Result, RsaPrivateKey};
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 use const_oid::AssociatedOid;
-use core::marker::PhantomData;
+use crypto_bigint::{modular::BoxedMontyParams, BoxedUint};
 use digest::{Digest, FixedOutput, HashMarker, Update};
 use rand_core::{CryptoRng, TryCryptoRng};
 use signature::{
@@ -27,66 +37,32 @@ use {
     serdect::serde::{de, ser, Deserialize, Serialize},
 };
 
-/// Signing key for `RSASSA-PKCS1-v1_5` signatures as described in [RFC8017 § 8.2].
+/// Signing key for `RSASSA-PKCS1-v1_5` signatures as described in
+/// [RFC8017 § 8.2]. Boxed alias over [`GenericSigningKey`] — equivalent
+/// to `GenericSigningKey<D, BoxedUint, BoxedMontyParams>`.
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
-#[derive(Debug, Clone)]
-pub struct SigningKey<D>
-where
-    D: Digest,
-{
-    inner: RsaPrivateKey,
-    prefix: Vec<u8>,
-    phantom: PhantomData<D>,
-}
+pub type SigningKey<D> = GenericSigningKey<D, BoxedUint, BoxedMontyParams>;
 
-impl<D> SigningKey<D>
+impl<D> GenericSigningKey<D, BoxedUint, BoxedMontyParams>
 where
     D: Digest + AssociatedOid,
 {
-    /// Create a new signing key with a prefix for the digest `D`.
-    pub fn new(key: RsaPrivateKey) -> Self {
-        Self {
-            inner: key,
-            prefix: pkcs1v15_generate_prefix::<D>(),
-            phantom: Default::default(),
-        }
-    }
-
-    /// Generate a new signing key with a prefix for the digest `D`.
+    /// Generate a fresh RSA key pair of the given bit size, then wrap
+    /// it in a signing key with the DigestInfo prefix for `D`.
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
-        Ok(Self {
-            inner: RsaPrivateKey::new(rng, bit_size)?,
-            prefix: pkcs1v15_generate_prefix::<D>(),
-            phantom: Default::default(),
-        })
+        Ok(Self::new(RsaPrivateKey::new(rng, bit_size)?))
     }
 }
 
-impl<D> SigningKey<D>
+impl<D> GenericSigningKey<D, BoxedUint, BoxedMontyParams>
 where
     D: Digest,
 {
-    /// Create a new signing key from the give RSA private key with an empty prefix.
-    ///
-    /// ## Note: unprefixed signatures are uncommon
-    ///
-    /// In most cases you'll want to use [`SigningKey::new`].
-    pub fn new_unprefixed(key: RsaPrivateKey) -> Self {
-        Self {
-            inner: key,
-            prefix: Vec::new(),
-            phantom: Default::default(),
-        }
-    }
-
-    /// Generate a new signing key with an empty prefix.
+    /// Generate a fresh RSA key pair of the given bit size with an empty
+    /// prefix (raw signatures, no DigestInfo wrapper).
     pub fn random_unprefixed<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
-        Ok(Self {
-            inner: RsaPrivateKey::new(rng, bit_size)?,
-            prefix: Vec::new(),
-            phantom: Default::default(),
-        })
+        Ok(Self::new_unprefixed(RsaPrivateKey::new(rng, bit_size)?))
     }
 }
 
@@ -201,15 +177,6 @@ where
 //
 // Other trait impls
 //
-
-impl<D> AsRef<RsaPrivateKey> for SigningKey<D>
-where
-    D: Digest,
-{
-    fn as_ref(&self) -> &RsaPrivateKey {
-        &self.inner
-    }
-}
 
 #[cfg(feature = "encoding")]
 impl<D> AssociatedAlgorithmIdentifier for SigningKey<D>
@@ -338,7 +305,6 @@ mod tests {
     #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
-        use crate::RsaPrivateKey;
         use rand::rngs::ChaCha8Rng;
         use rand_core::SeedableRng;
         use serde_test::{assert_tokens, Configure, Token};

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -17,6 +17,7 @@ use crate::{
         PublicKeyParts, UnsignedModularInt,
     },
 };
+use core::fmt;
 use core::marker::PhantomData;
 use digest::{Digest, FixedOutputReset};
 use rand_core::TryCryptoRng;
@@ -40,6 +41,23 @@ where
     pub(super) inner: GenericRsaPrivateKey<T, M>,
     pub(super) salt_len: usize,
     pub(super) phantom: PhantomData<D>,
+}
+
+// Manual `Debug` — `#[derive]` would synthesize unwanted bounds on
+// `D`/`T`/`M`; the inner private key already redacts `d`.
+impl<D, T, M> fmt::Debug for GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize,
+    M: ModulusParams<Modulus = T>,
+    GenericRsaPrivateKey<T, M>: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKey")
+            .field("inner", &self.inner)
+            .field("salt_len", &self.salt_len)
+            .finish()
+    }
 }
 
 // Manual Clone impls — split by `private-key` cfg to avoid imposing

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -53,7 +53,7 @@ where
     GenericRsaPrivateKey<T, M>: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SigningKey")
+        f.debug_struct("GenericSigningKey")
             .field("inner", &self.inner)
             .field("salt_len", &self.salt_len)
             .finish()

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -1,6 +1,19 @@
-use super::{sign_digest, Signature, VerifyingKey};
+//! Boxed RSASSA-PSS signing key — alloc-side type alias and
+//! specializations over [`super::GenericSigningKey`]. Mirrors the
+//! pattern on the verify side (`verifying_key.rs`).
+//!
+//! The struct, generic constructors (`new`, `new_with_salt_len`),
+//! `Clone`, `Debug`, `AsRef<GenericRsaPrivateKey<T, M>>`, `Zeroize`,
+//! and the `try_sign_*_into` family all live on
+//! [`super::GenericSigningKey`]. This file holds only what's tied to
+//! the boxed substitution: keygen-bearing constructors, the
+//! `signature::*Signer` trait family (delegating to the alloc-side
+//! `sign_digest(...)`), encoding, serde, and the legacy `Keypair`
+//! wiring.
+
+use super::{sign_digest, GenericSigningKey, Signature, VerifyingKey};
 use crate::{Result, RsaPrivateKey};
-use core::marker::PhantomData;
+use crypto_bigint::{modular::BoxedMontyParams, BoxedUint};
 use digest::{Digest, FixedOutputReset, Update};
 use rand_core::{CryptoRng, TryCryptoRng};
 use signature::{
@@ -34,60 +47,33 @@ use {
 };
 
 /// Signing key for producing RSASSA-PSS signatures as described in
-/// [RFC8017 § 8.1].
+/// [RFC8017 § 8.1]. Boxed alias over [`GenericSigningKey`] — equivalent
+/// to `GenericSigningKey<D, BoxedUint, BoxedMontyParams>`.
 ///
 /// [RFC8017 § 8.1]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.1
-#[derive(Debug, Clone)]
-pub struct SigningKey<D>
+pub type SigningKey<D> = GenericSigningKey<D, BoxedUint, BoxedMontyParams>;
+
+impl<D> GenericSigningKey<D, BoxedUint, BoxedMontyParams>
 where
     D: Digest,
 {
-    inner: RsaPrivateKey,
-    salt_len: usize,
-    phantom: PhantomData<D>,
-}
-
-impl<D> SigningKey<D>
-where
-    D: Digest,
-{
-    /// Create a new RSASSA-PSS signing key.
-    /// Digest output size is used as a salt length.
-    pub fn new(key: RsaPrivateKey) -> Self {
-        Self::new_with_salt_len(key, <D as Digest>::output_size())
-    }
-
-    /// Create a new RSASSA-PSS signing key with a salt of the given length.
-    pub fn new_with_salt_len(key: RsaPrivateKey, salt_len: usize) -> Self {
-        Self {
-            inner: key,
-            salt_len,
-            phantom: Default::default(),
-        }
-    }
-
-    /// Generate a new random RSASSA-PSS signing key.
-    /// Digest output size is used as a salt length.
+    /// Generate a fresh RSASSA-PSS signing key. Digest output size is
+    /// used as a salt length.
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         Self::random_with_salt_len(rng, bit_size, <D as Digest>::output_size())
     }
 
-    /// Generate a new random RSASSA-PSS signing key with a salt of the given length.
+    /// Generate a fresh RSASSA-PSS signing key with a salt of the given
+    /// length.
     pub fn random_with_salt_len<R: CryptoRng + ?Sized>(
         rng: &mut R,
         bit_size: usize,
         salt_len: usize,
     ) -> Result<Self> {
-        Ok(Self {
-            inner: RsaPrivateKey::new(rng, bit_size)?,
+        Ok(Self::new_with_salt_len(
+            RsaPrivateKey::new(rng, bit_size)?,
             salt_len,
-            phantom: Default::default(),
-        })
-    }
-
-    /// Return specified salt length for this key
-    pub fn salt_len(&self) -> usize {
-        self.salt_len
+        ))
     }
 }
 
@@ -195,15 +181,6 @@ where
 //
 // Other trait impls
 //
-
-impl<D> AsRef<RsaPrivateKey> for SigningKey<D>
-where
-    D: Digest,
-{
-    fn as_ref(&self) -> &RsaPrivateKey {
-        &self.inner
-    }
-}
 
 #[cfg(feature = "encoding")]
 impl<D> AssociatedAlgorithmIdentifier for SigningKey<D>
@@ -325,7 +302,6 @@ mod tests {
     #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
-        use crate::RsaPrivateKey;
         use rand::rngs::ChaCha8Rng;
         use rand_core::SeedableRng;
         use serde_test::{assert_tokens, Configure, Token};


### PR DESCRIPTION
## Summary
- Replaces `pub struct SigningKey<D>` with `pub type SigningKey<D> = GenericSigningKey<D, BoxedUint, BoxedMontyParams>` in both `pkcs1v15` and `pss`, mirroring the verify-side pattern (`VerifyingKey<D>` is already a type alias of `GenericVerifyingKey<D, BoxedUint, BoxedMontyParams>`).
- Duplicate `new` / `new_unprefixed` / `new_with_salt_len` / `AsRef<RsaPrivateKey>` / `Clone` / `Debug` impls drop out — provided by the heapless `GenericSigningKey<D, T, M>` and reachable through the alias.
- `signing_key.rs` (gutted to ~half its line count on both sides) now holds only what's tied to the boxed substitution: keygen-bearing `random` / `random_unprefixed` / `random_with_salt_len`; the full `signature::*Signer` trait family; encoding (`AssociatedAlgorithmIdentifier`, `EncodePrivateKey`, `SignatureAlgorithmIdentifier`, `DynSignatureAlgorithmIdentifier`, PKCS#8 `TryFrom`); `From`; `Keypair`; `ZeroizeOnDrop`; `PartialEq`; serde.
- Adds a manual `Debug` impl to `GenericSigningKey<D, T, M>` so the alias inherits a redacting `Debug`. Manual rather than `#[derive]` to avoid spurious `D: Debug` / `T: Debug` / `M: Debug` bounds.

## Bug fixed in the same PR

The inherent `GenericSigningKey::verifying_key()` helper from Phase 2 shadowed `signature::Keypair::verifying_key` once `SigningKey<D>` became the boxed alias — returning a verifying key with the DigestInfo prefix freshly generated from `D` rather than the signing key's actual prefix. Broke unprefixed signing keys' verify round-trip (caught by `test_unpadded_signature_hazmat`). Renamed the inherent helper to `to_verifying_key`, matching the existing `RsaPrivateKey::to_public_key` convention.

## Test plan
- [x] `cargo check` (default)
- [x] `cargo check --no-default-features --features modmath` (heapless)
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo test --lib` (96 tests)
- [x] `cargo test --all-features --tests` (integration + wycheproof, 17 tests)
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Alias RSA SigningKey types to the generic GenericSigningKey with boxed backends and adjust helpers accordingly while tightening debug behavior and fixing verifying key derivation for unprefixed keys.

New Features:
- Expose pkcs1v15 and PSS SigningKey<D> as type aliases over GenericSigningKey<D, BoxedUint, BoxedMontyParams> instead of concrete structs.
- Provide key generation helpers on the boxed GenericSigningKey variants for PKCS#1 v1.5 and PSS RSA signing keys.
- Add a redacting manual Debug implementation for GenericSigningKey so alias-based signing keys inherit safe debug output.

Bug Fixes:
- Rename the inherent verifying_key helper on GenericSigningKey to to_verifying_key to avoid shadowing signature::Keypair::verifying_key and to preserve existing prefixes, restoring correct verification for unprefixed signing keys.

Enhancements:
- Reduce duplication in pkcs1v15 and PSS signing key modules by delegating initialization and accessors to GenericSigningKey.
- Align naming and behavior of verifying-key derivation with existing RsaPrivateKey::to_public_key conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer debug output for signing keys, making it easier to inspect key details during troubleshooting.
  * Renamed the method for deriving a matching verifying key to `to_verifying_key()` for a clearer API.

* **Bug Fixes**
  * Improved consistency in RSA signing key handling across PKCS#1 v1.5 and PSS key types.
  * Updated signing key behavior to work with a more unified internal representation without changing normal usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->