### PR TITLE
Fold-2d: pss::BlindedSigningKey becomes a newtype over SigningKey

### DIFF
--- a/src/pss/blinded_signing_key.rs
+++ b/src/pss/blinded_signing_key.rs
@@ -1,6 +1,5 @@
-use super::{sign_digest, Signature, VerifyingKey};
+use super::{sign_digest, Signature, SigningKey, VerifyingKey};
 use crate::{Result, RsaPrivateKey};
-use core::marker::PhantomData;
 use digest::{Digest, FixedOutputReset, HashMarker, Update};
 use rand_core::{CryptoRng, TryCryptoRng};
 use signature::{
@@ -27,42 +26,37 @@ use {
 
 /// Signing key for producing "blinded" RSASSA-PSS signatures as described in
 /// [draft-irtf-cfrg-rsa-blind-signatures](https://datatracker.ietf.org/doc/draft-irtf-cfrg-rsa-blind-signatures/).
-#[derive(Debug, Clone)]
-pub struct BlindedSigningKey<D>
+///
+/// Thin newtype over [`SigningKey`] — same storage, same encoding /
+/// serde / keypair / `AsRef<RsaPrivateKey>` behavior. The only
+/// behavioral difference: the `signature::*Signer` impls pass
+/// `blinded = true` to the underlying `sign_digest`, applying
+/// blinding to the private-key operation.
+#[derive(Clone, Debug)]
+pub struct BlindedSigningKey<D>(SigningKey<D>)
 where
-    D: Digest,
-{
-    inner: RsaPrivateKey,
-    salt_len: usize,
-    phantom: PhantomData<D>,
-}
+    D: Digest;
 
 impl<D> BlindedSigningKey<D>
 where
     D: Digest,
 {
     /// Create a new RSASSA-PSS signing key which produces "blinded"
-    /// signatures.
-    /// Digest output size is used as a salt length.
+    /// signatures. Digest output size is used as a salt length.
     pub fn new(key: RsaPrivateKey) -> Self {
-        Self::new_with_salt_len(key, <D as Digest>::output_size())
+        Self(SigningKey::new(key))
     }
 
     /// Create a new RSASSA-PSS signing key which produces "blinded"
     /// signatures with a salt of the given length.
     pub fn new_with_salt_len(key: RsaPrivateKey, salt_len: usize) -> Self {
-        Self {
-            inner: key,
-            salt_len,
-            phantom: Default::default(),
-        }
+        Self(SigningKey::new_with_salt_len(key, salt_len))
     }
 
     /// Create a new random RSASSA-PSS signing key which produces "blinded"
-    /// signatures.
-    /// Digest output size is used as a salt length.
+    /// signatures. Digest output size is used as a salt length.
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
-        Self::random_with_salt_len(rng, bit_size, <D as Digest>::output_size())
+        SigningKey::random(rng, bit_size).map(Self)
     }
 
     /// Create a new random RSASSA-PSS signing key which produces "blinded"
@@ -72,21 +66,19 @@ where
         bit_size: usize,
         salt_len: usize,
     ) -> Result<Self> {
-        Ok(Self {
-            inner: RsaPrivateKey::new(rng, bit_size)?,
-            salt_len,
-            phantom: Default::default(),
-        })
+        SigningKey::random_with_salt_len(rng, bit_size, salt_len).map(Self)
     }
 
     /// Return specified salt length for this key
     pub fn salt_len(&self) -> usize {
-        self.salt_len
+        self.0.salt_len()
     }
 }
 
 //
-// `*Signer` trait impls
+// `*Signer` trait impls — the only carriers of the blinded behavior.
+// Reach into the inner `SigningKey<D>`'s `pub(super)` fields to call
+// `sign_digest` with `blinded = true`.
 //
 
 impl<D> RandomizedSigner<Signature> for BlindedSigningKey<D>
@@ -114,9 +106,15 @@ where
         let mut digest = D::new();
         msg.iter()
             .for_each(|slice| <D as Digest>::update(&mut digest, slice));
-        sign_digest::<_, D>(rng, true, &self.inner, &digest.finalize(), self.salt_len)?
-            .as_slice()
-            .try_into()
+        sign_digest::<_, D>(
+            rng,
+            true,
+            &self.0.inner,
+            &digest.finalize(),
+            self.0.salt_len,
+        )?
+        .as_slice()
+        .try_into()
     }
 }
 
@@ -134,9 +132,15 @@ where
     ) -> signature::Result<Signature> {
         let mut digest = D::default();
         f(&mut digest)?;
-        sign_digest::<_, D>(rng, true, &self.inner, &digest.finalize(), self.salt_len)?
-            .as_slice()
-            .try_into()
+        sign_digest::<_, D>(
+            rng,
+            true,
+            &self.0.inner,
+            &digest.finalize(),
+            self.0.salt_len,
+        )?
+        .as_slice()
+        .try_into()
     }
 }
 
@@ -149,14 +153,14 @@ where
         rng: &mut R,
         prehash: &[u8],
     ) -> signature::Result<Signature> {
-        sign_digest::<_, D>(rng, true, &self.inner, prehash, self.salt_len)?
+        sign_digest::<_, D>(rng, true, &self.0.inner, prehash, self.0.salt_len)?
             .as_slice()
             .try_into()
     }
 }
 
 //
-// Other trait impls
+// Other trait impls — all delegate to the inner `SigningKey<D>`.
 //
 
 impl<D> AsRef<RsaPrivateKey> for BlindedSigningKey<D>
@@ -164,7 +168,7 @@ where
     D: Digest,
 {
     fn as_ref(&self) -> &RsaPrivateKey {
-        &self.inner
+        self.0.as_ref()
     }
 }
 
@@ -184,7 +188,7 @@ where
     D: Digest + AssociatedOid,
 {
     fn signature_algorithm_identifier(&self) -> spki::Result<AlgorithmIdentifierOwned> {
-        get_pss_signature_algo_id::<D>(self.salt_len as u8)
+        get_pss_signature_algo_id::<D>(self.0.salt_len() as u8)
     }
 }
 
@@ -194,7 +198,7 @@ where
     D: Digest,
 {
     fn to_pkcs8_der(&self) -> pkcs8::Result<SecretDocument> {
-        self.inner.to_pkcs8_der()
+        self.0.to_pkcs8_der()
     }
 }
 
@@ -212,7 +216,7 @@ where
     D: Digest,
 {
     fn from(key: BlindedSigningKey<D>) -> Self {
-        key.inner
+        key.0.into()
     }
 }
 
@@ -221,12 +225,9 @@ where
     D: Digest,
 {
     type VerifyingKey = VerifyingKey<D>;
+
     fn verifying_key(&self) -> Self::VerifyingKey {
-        VerifyingKey {
-            inner: self.inner.to_public_key(),
-            salt_len: Some(self.salt_len),
-            phantom: Default::default(),
-        }
+        Keypair::verifying_key(&self.0)
     }
 }
 
@@ -238,7 +239,7 @@ where
     type Error = pkcs8::Error;
 
     fn try_from(private_key_info: pkcs8::PrivateKeyInfoRef<'_>) -> pkcs8::Result<Self> {
-        RsaPrivateKey::try_from(private_key_info).map(Self::new)
+        SigningKey::try_from(private_key_info).map(Self)
     }
 }
 
@@ -249,7 +250,7 @@ where
     D: Digest,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner && self.salt_len == other.salt_len
+        self.0 == other.0
     }
 }
 

--- a/src/pss/blinded_signing_key.rs
+++ b/src/pss/blinded_signing_key.rs
@@ -77,8 +77,9 @@ where
 
 //
 // `*Signer` trait impls — the only carriers of the blinded behavior.
-// Reach into the inner `SigningKey<D>`'s `pub(super)` fields to call
-// `sign_digest` with `blinded = true`.
+// Delegate through `SigningKey<D>`'s public accessors (`AsRef<RsaPrivateKey>`
+// and `salt_len()`) to call `sign_digest` with `blinded = true`, keeping
+// the wrapper independent of `SigningKey`'s field layout.
 //
 
 impl<D> RandomizedSigner<Signature> for BlindedSigningKey<D>
@@ -109,9 +110,9 @@ where
         sign_digest::<_, D>(
             rng,
             true,
-            &self.0.inner,
+            self.0.as_ref(),
             &digest.finalize(),
-            self.0.salt_len,
+            self.0.salt_len(),
         )?
         .as_slice()
         .try_into()
@@ -135,9 +136,9 @@ where
         sign_digest::<_, D>(
             rng,
             true,
-            &self.0.inner,
+            self.0.as_ref(),
             &digest.finalize(),
-            self.0.salt_len,
+            self.0.salt_len(),
         )?
         .as_slice()
         .try_into()
@@ -153,7 +154,7 @@ where
         rng: &mut R,
         prehash: &[u8],
     ) -> signature::Result<Signature> {
-        sign_digest::<_, D>(rng, true, &self.0.inner, prehash, self.0.salt_len)?
+        sign_digest::<_, D>(rng, true, self.0.as_ref(), prehash, self.0.salt_len())?
             .as_slice()
             .try_into()
     }


### PR DESCRIPTION
## Summary
- `BlindedSigningKey<D>` and `SigningKey<D>` had structurally identical storage (`RsaPrivateKey`, `salt_len`, `PhantomData<D>`); only the four `signature::*Signer` impls differed, passing `blinded = true` to `sign_digest`.
- Fold: make `BlindedSigningKey<D>` a thin newtype — `pub struct BlindedSigningKey<D>(SigningKey<D>) where D: Digest;`. Storage shape is single-sourced through `SigningKey<D>` (= the fold-2c boxed alias).
- The four `*Signer` impls stay — they're the behavior carriers — and reach the inner private key + salt_len via `SigningKey<D>`'s `pub(super)` fields. All other trait surface (`AsRef<RsaPrivateKey>`, `From`, `Keypair`, encoding, serde, `PartialEq`, `ZeroizeOnDrop`, `Clone`, `Debug`) delegates to `self.0`.

Line count roughly flat (Rust doesn't auto-forward traits to newtypes, so the impl list stays), but the fold is real: future changes to the signing-key storage shape only land on `GenericSigningKey<D, T, M>` and propagate.

## Test plan
- [x] `cargo check` (default)
- [x] `cargo check --no-default-features --features modmath` (heapless)
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo test --lib` (96 tests)
- [x] `cargo test --all-features --tests` (17 integration / wycheproof)
- [x] `cargo test --doc`
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Enhancements:
- Delegate blinded signing key construction, random generation, encoding, keypair, and trait behavior through the underlying `SigningKey` to centralize RSA-PSS key handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the underlying handling of blinded signing keys to align more closely with the existing signing key implementation.
  * Kept the public API unchanged while preserving signing, verification, and key encoding behavior.
  * Improved consistency across key-related operations, including salt length handling and key comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->