### PR TITLE
Phase 4: deprecate legacy PrivateKeyParts

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -6,7 +6,7 @@
 #![cfg(feature = "encoding")]
 
 use crate::{
-    traits::{PrivateKeyParts, PublicKeyParts},
+    traits::{GenericPrivateKeyParts, PublicKeyParts},
     RsaPrivateKey, RsaPublicKey,
 };
 use core::convert::{TryFrom, TryInto};

--- a/src/key.rs
+++ b/src/key.rs
@@ -36,6 +36,7 @@ use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
 use crate::traits::keys::PublicKeyParts;
 #[cfg(feature = "private-key")]
+#[allow(deprecated)]
 use crate::traits::keys::{CrtValue, PrivateKeyParts};
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 use crate::traits::keys::{GenericPrivateKeyParts, RawPrivateKeyConstructible};
@@ -1026,7 +1027,10 @@ impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     }
 }
 
+// Kept impl'd for backwards compat with external consumers bounding on
+// the deprecated trait. New code should use `GenericPrivateKeyParts`.
 #[cfg(feature = "private-key")]
+#[allow(deprecated)]
 impl PrivateKeyParts for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     fn d(&self) -> &BoxedUint {
         &self.d
@@ -1212,7 +1216,7 @@ impl<'de> Deserialize<'de> for RsaPrivateKey {
 mod tests {
     use super::*;
     use crate::algorithms::rsa::{rsa_decrypt_and_check, rsa_encrypt};
-    use crate::traits::{PrivateKeyParts, PublicKeyParts};
+    use crate::traits::{GenericPrivateKeyParts, PublicKeyParts};
 
     use hex_literal::hex;
     use rand::rngs::ChaCha8Rng;
@@ -1248,7 +1252,8 @@ mod tests {
         private_key.validate().expect("invalid private key");
 
         assert!(
-            PrivateKeyParts::d(private_key) < PublicKeyParts::n(private_key).as_ref(),
+            GenericPrivateKeyParts::<BoxedUint>::d(private_key)
+                < PublicKeyParts::n(private_key).as_ref(),
             "private exponent too large"
         );
 
@@ -1542,7 +1547,7 @@ mod tests {
         let ref_key = RsaPrivateKey::from_pkcs8_der(RSA_2048_PRIV_DER).unwrap();
         assert_eq!(ref_key.validate(), Ok(()));
 
-        let primes = PrivateKeyParts::primes(&ref_key).to_vec();
+        let primes = GenericPrivateKeyParts::<BoxedUint>::primes(&ref_key).to_vec();
 
         let exp = PublicKeyParts::e(&ref_key);
         let key = RsaPrivateKey::from_primes(primes, exp.clone())
@@ -1551,10 +1556,19 @@ mod tests {
 
         assert_eq!(PublicKeyParts::n(&key), PublicKeyParts::n(&ref_key));
 
-        assert_eq!(PrivateKeyParts::dp(&key), PrivateKeyParts::dp(&ref_key));
-        assert_eq!(PrivateKeyParts::dq(&key), PrivateKeyParts::dq(&ref_key));
+        assert_eq!(
+            GenericPrivateKeyParts::<BoxedUint>::dp(&key),
+            GenericPrivateKeyParts::<BoxedUint>::dp(&ref_key)
+        );
+        assert_eq!(
+            GenericPrivateKeyParts::<BoxedUint>::dq(&key),
+            GenericPrivateKeyParts::<BoxedUint>::dq(&ref_key)
+        );
 
-        assert_eq!(PrivateKeyParts::d(&key), PrivateKeyParts::d(&ref_key));
+        assert_eq!(
+            GenericPrivateKeyParts::<BoxedUint>::d(&key),
+            GenericPrivateKeyParts::<BoxedUint>::d(&ref_key)
+        );
     }
 
     #[test]
@@ -1565,7 +1579,7 @@ mod tests {
         let ref_key = RsaPrivateKey::from_pkcs8_der(RSA_2048_SP800_PRIV_DER).unwrap();
         assert_eq!(ref_key.validate(), Ok(()));
 
-        let primes = PrivateKeyParts::primes(&ref_key).to_vec();
+        let primes = GenericPrivateKeyParts::<BoxedUint>::primes(&ref_key).to_vec();
         let exp = PublicKeyParts::e(&ref_key);
 
         let key = RsaPrivateKey::from_p_q(primes[0].clone(), primes[1].clone(), exp.clone())
@@ -1574,10 +1588,19 @@ mod tests {
 
         assert_eq!(PublicKeyParts::n(&key), PublicKeyParts::n(&ref_key));
 
-        assert_eq!(PrivateKeyParts::dp(&key), PrivateKeyParts::dp(&ref_key));
-        assert_eq!(PrivateKeyParts::dq(&key), PrivateKeyParts::dq(&ref_key));
+        assert_eq!(
+            GenericPrivateKeyParts::<BoxedUint>::dp(&key),
+            GenericPrivateKeyParts::<BoxedUint>::dp(&ref_key)
+        );
+        assert_eq!(
+            GenericPrivateKeyParts::<BoxedUint>::dq(&key),
+            GenericPrivateKeyParts::<BoxedUint>::dq(&ref_key)
+        );
 
-        assert_eq!(PrivateKeyParts::d(&key), PrivateKeyParts::d(&ref_key));
+        assert_eq!(
+            GenericPrivateKeyParts::<BoxedUint>::d(&key),
+            GenericPrivateKeyParts::<BoxedUint>::d(&ref_key)
+        );
     }
 
     #[test]
@@ -1621,7 +1644,10 @@ mod tests {
         let key_with_large_exp = key_with_large_exp.unwrap();
         assert_eq!(PublicKeyParts::e(&key_with_large_exp), &large_e);
         assert_eq!(PublicKeyParts::n(&key_with_large_exp).as_ref(), &n);
-        assert_eq!(PrivateKeyParts::d(&key_with_large_exp), &d);
+        assert_eq!(
+            GenericPrivateKeyParts::<BoxedUint>::d(&key_with_large_exp),
+            &d
+        );
 
         // Verify that the key is still cryptographically valid (de ≡ 1 mod λ(n))
         // by checking that validation with skip_exponent_size passes

--- a/src/key.rs
+++ b/src/key.rs
@@ -1252,8 +1252,7 @@ mod tests {
         private_key.validate().expect("invalid private key");
 
         assert!(
-            GenericPrivateKeyParts::<BoxedUint>::d(private_key)
-                < PublicKeyParts::n(private_key).as_ref(),
+            GenericPrivateKeyParts::d(private_key) < PublicKeyParts::n(private_key).as_ref(),
             "private exponent too large"
         );
 
@@ -1547,7 +1546,7 @@ mod tests {
         let ref_key = RsaPrivateKey::from_pkcs8_der(RSA_2048_PRIV_DER).unwrap();
         assert_eq!(ref_key.validate(), Ok(()));
 
-        let primes = GenericPrivateKeyParts::<BoxedUint>::primes(&ref_key).to_vec();
+        let primes = GenericPrivateKeyParts::primes(&ref_key).to_vec();
 
         let exp = PublicKeyParts::e(&ref_key);
         let key = RsaPrivateKey::from_primes(primes, exp.clone())
@@ -1557,17 +1556,17 @@ mod tests {
         assert_eq!(PublicKeyParts::n(&key), PublicKeyParts::n(&ref_key));
 
         assert_eq!(
-            GenericPrivateKeyParts::<BoxedUint>::dp(&key),
-            GenericPrivateKeyParts::<BoxedUint>::dp(&ref_key)
+            GenericPrivateKeyParts::dp(&key),
+            GenericPrivateKeyParts::dp(&ref_key)
         );
         assert_eq!(
-            GenericPrivateKeyParts::<BoxedUint>::dq(&key),
-            GenericPrivateKeyParts::<BoxedUint>::dq(&ref_key)
+            GenericPrivateKeyParts::dq(&key),
+            GenericPrivateKeyParts::dq(&ref_key)
         );
 
         assert_eq!(
-            GenericPrivateKeyParts::<BoxedUint>::d(&key),
-            GenericPrivateKeyParts::<BoxedUint>::d(&ref_key)
+            GenericPrivateKeyParts::d(&key),
+            GenericPrivateKeyParts::d(&ref_key)
         );
     }
 
@@ -1579,7 +1578,7 @@ mod tests {
         let ref_key = RsaPrivateKey::from_pkcs8_der(RSA_2048_SP800_PRIV_DER).unwrap();
         assert_eq!(ref_key.validate(), Ok(()));
 
-        let primes = GenericPrivateKeyParts::<BoxedUint>::primes(&ref_key).to_vec();
+        let primes = GenericPrivateKeyParts::primes(&ref_key).to_vec();
         let exp = PublicKeyParts::e(&ref_key);
 
         let key = RsaPrivateKey::from_p_q(primes[0].clone(), primes[1].clone(), exp.clone())
@@ -1589,17 +1588,17 @@ mod tests {
         assert_eq!(PublicKeyParts::n(&key), PublicKeyParts::n(&ref_key));
 
         assert_eq!(
-            GenericPrivateKeyParts::<BoxedUint>::dp(&key),
-            GenericPrivateKeyParts::<BoxedUint>::dp(&ref_key)
+            GenericPrivateKeyParts::dp(&key),
+            GenericPrivateKeyParts::dp(&ref_key)
         );
         assert_eq!(
-            GenericPrivateKeyParts::<BoxedUint>::dq(&key),
-            GenericPrivateKeyParts::<BoxedUint>::dq(&ref_key)
+            GenericPrivateKeyParts::dq(&key),
+            GenericPrivateKeyParts::dq(&ref_key)
         );
 
         assert_eq!(
-            GenericPrivateKeyParts::<BoxedUint>::d(&key),
-            GenericPrivateKeyParts::<BoxedUint>::d(&ref_key)
+            GenericPrivateKeyParts::d(&key),
+            GenericPrivateKeyParts::d(&ref_key)
         );
     }
 
@@ -1644,10 +1643,7 @@ mod tests {
         let key_with_large_exp = key_with_large_exp.unwrap();
         assert_eq!(PublicKeyParts::e(&key_with_large_exp), &large_e);
         assert_eq!(PublicKeyParts::n(&key_with_large_exp).as_ref(), &n);
-        assert_eq!(
-            GenericPrivateKeyParts::<BoxedUint>::d(&key_with_large_exp),
-            &d
-        );
+        assert_eq!(GenericPrivateKeyParts::d(&key_with_large_exp), &d);
 
         // Verify that the key is still cryptographically valid (de ≡ 1 mod λ(n))
         // by checking that validation with skip_exponent_size passes

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,9 +11,6 @@ pub use keys::GenericPrivateKeyParts;
 #[cfg(feature = "private-key")]
 #[allow(deprecated)]
 pub use keys::PrivateKeyParts;
-#[cfg(not(feature = "private-key"))]
-pub use keys::PublicKeyParts;
-#[cfg(feature = "private-key")]
 pub use keys::PublicKeyParts;
 pub use modular::{FixedWidthUnsignedInt, IntegerResize, NonZero, Odd, UnsignedModularInt};
 pub use padding::{PaddingScheme, SignatureScheme};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,9 +8,12 @@ mod padding;
 pub use encryption::{Decryptor, EncryptingKeypair, RandomizedDecryptor, RandomizedEncryptor};
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub use keys::GenericPrivateKeyParts;
+#[cfg(feature = "private-key")]
+#[allow(deprecated)]
+pub use keys::PrivateKeyParts;
 #[cfg(not(feature = "private-key"))]
 pub use keys::PublicKeyParts;
 #[cfg(feature = "private-key")]
-pub use keys::{PrivateKeyParts, PublicKeyParts};
+pub use keys::PublicKeyParts;
 pub use modular::{FixedWidthUnsignedInt, IntegerResize, NonZero, Odd, UnsignedModularInt};
 pub use padding::{PaddingScheme, SignatureScheme};

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -154,7 +154,7 @@ where
 #[cfg(feature = "private-key")]
 #[deprecated(
     since = "0.3.0",
-    note = "use `GenericPrivateKeyParts<BoxedUint>` (generic over backend) instead; this trait will be removed in a future major version"
+    note = "use `GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>` (generic over backend) instead; this trait will be removed in a future major version"
 )]
 pub trait PrivateKeyParts: PublicKeyParts<BoxedUint> {
     /// Returns the private exponent of the key.

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -145,7 +145,17 @@ where
 }
 
 /// Components of an RSA private key.
+///
+/// **Deprecated** — superseded by [`GenericPrivateKeyParts`], which is
+/// generic over the integer / Montgomery-parameter backend. Existing
+/// `K: PrivateKeyParts` types still work but new code should bound on
+/// `GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>`
+/// instead.
 #[cfg(feature = "private-key")]
+#[deprecated(
+    since = "0.3.0",
+    note = "use `GenericPrivateKeyParts<BoxedUint>` (generic over backend) instead; this trait will be removed in a future major version"
+)]
 pub trait PrivateKeyParts: PublicKeyParts<BoxedUint> {
     /// Returns the private exponent of the key.
     fn d(&self) -> &BoxedUint;

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -6,7 +6,7 @@ use crypto_bigint::{BoxedUint, CtEq};
 use hex_literal::hex;
 use rsa::{
     pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey},
-    traits::{PrivateKeyParts, PublicKeyParts},
+    traits::{GenericPrivateKeyParts, PublicKeyParts},
     RsaPrivateKey, RsaPublicKey,
 };
 

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -8,7 +8,7 @@ use rsa::{
     pkcs1v15,
     pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey},
     pss,
-    traits::{PrivateKeyParts, PublicKeyParts},
+    traits::{GenericPrivateKeyParts, PublicKeyParts},
     RsaPrivateKey, RsaPublicKey,
 };
 use sha2::Sha256;


### PR DESCRIPTION
## Summary
- Adds `#[deprecated(since = "0.3.0", note = "use \`GenericPrivateKeyParts<BoxedUint>\` instead")]` to the legacy `PrivateKeyParts` trait. External consumers bounding on `PrivateKeyParts` get a deprecation warning but their code keeps compiling — the `impl PrivateKeyParts for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>` stays in place (now with `#[allow(deprecated)]`), and the trait is still exported from `crate::traits` (`#[allow(deprecated)]` on the re-export).
- Internal callers migrated to `GenericPrivateKeyParts<BoxedUint>`: `src/encoding.rs` (PKCS#1 / PKCS#8 encode paths), `src/key.rs` tests, `tests/pkcs1.rs`, `tests/pkcs8.rs`.

## Why now

Fold-1 (PR #27) bound the alloc-side algorithm primitives on `GenericPrivateKeyParts`; Folds 2a–2d folded the storage + wrapper layer. Trait deprecation is the next step per the CLAUDE.md roadmap, setting up the eventual Phase 4 rename (drop impl + trait, then rename `GenericPrivateKeyParts` → `PrivateKeyParts`).

## Out of scope for this PR

- Removing the `impl PrivateKeyParts for ...` and trait itself — that's a major-version break, separate PR.
- `crt_values()` (only on the legacy trait, no generic equivalent) — kept available through the deprecated path; nothing internal calls it.

## Test plan
- [x] `cargo check` (default)
- [x] `cargo check --no-default-features --features modmath`
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo test --lib` (96)
- [x] `cargo test --all-features --tests` (17 integration / wycheproof)
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Deprecate the legacy `PrivateKeyParts` trait in favor of the generic `GenericPrivateKeyParts<BoxedUint>` while preserving backward compatibility for external consumers.

Enhancements:
- Migrate internal key handling and encoding logic to use `GenericPrivateKeyParts<BoxedUint>` instead of the legacy `PrivateKeyParts` trait.
- Retain the `PrivateKeyParts` implementation and re-export behind deprecation annotations to avoid breaking existing code.

Documentation:
- Add API documentation noting the deprecation of `PrivateKeyParts` and directing users to `GenericPrivateKeyParts<BoxedUint>` as the replacement.

Tests:
- Update RSA key tests and PKCS#1/PKCS#8 integration tests to depend on `GenericPrivateKeyParts<BoxedUint>` rather than the deprecated `PrivateKeyParts` trait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RSA private-key handling to use the newer generic key-parts trait.
  * Kept legacy private-key support available while marking the older interface as deprecated.
  * Adjusted key import and validation tests to match the updated trait usage.

* **Chores**
  * Refined exported trait re-exports for clearer feature-based availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->