### PR TITLE
Fix sign_into precision check to use modulus bits, not container width

### DIFF
--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -237,11 +237,14 @@ where
 {
     // `k` must equal the ceiling-byte length of the modulus, matching
     // `PublicKeyParts::size()` (which the public-side verifier uses for
-    // its own length check). `div_ceil` not floor div — for a key whose
-    // `bits_precision()` is not a multiple of 8 (e.g. an imported
-    // 2049-bit RSA modulus on the BoxedUint backend) the floor would
-    // reject the only `k` value that would actually round-trip.
-    if k != (n_params.bits_precision() as usize).div_ceil(8) {
+    // its own length check). Use the actual modulus bit-length, not the
+    // container width — for a shorter modulus stored in a wider integer
+    // (e.g. a 1024-bit RSA key on `U2048`) `bits_precision()` returns
+    // the container width and would reject the only valid `k`. Also
+    // `div_ceil` not floor — for a key whose bit-length isn't a
+    // multiple of 8 (e.g. an imported 2049-bit RSA modulus) the floor
+    // would reject the only `k` value that would actually round-trip.
+    if k != (n_params.modulus().as_ref().bits() as usize).div_ceil(8) {
         return Err(Error::InvalidArguments);
     }
     // Fail fast on a too-small `sig_storage` rather than letting

--- a/src/algorithms/pss.rs
+++ b/src/algorithms/pss.rs
@@ -208,7 +208,7 @@ where
 ///
 /// 1. [`emsa_pss_encode_into`] — build the EM encoding for `(m_hash, salt)`
 ///    into `em_storage`. `em_bits = key_bits - 1` per RFC 8017 § 8.1.1 is
-///    derived internally from `n_params.bits_precision()`.
+///    derived internally from the actual modulus bit-length.
 /// 2. [`UnsignedModularInt::try_from_be_bytes_vartime`] — bytes → integer.
 /// 3. [`crate::algorithms::rsa::rsa_private_op_and_check`] — CT in the
 ///    secret exponent on the Ct-personality heapless path, with a
@@ -254,11 +254,16 @@ where
 {
     // `k` must equal the ceiling-byte length of the modulus, matching
     // `PublicKeyParts::size()` (which the public-side verifier uses for
-    // its own length check). `div_ceil` not floor div — for a key whose
-    // `bits_precision()` is not a multiple of 8 (e.g. an imported
-    // 2049-bit RSA modulus on the BoxedUint backend) the floor would
-    // reject the only `k` value that would actually round-trip.
-    let key_bits = n_params.bits_precision() as usize;
+    // its own length check). Use the actual modulus bit-length, not the
+    // container width — for a shorter modulus stored in a wider integer
+    // (e.g. a 1024-bit RSA key on `U2048`) `bits_precision()` returns
+    // the container width and would reject the only valid `k`. Also
+    // `div_ceil` not floor — for a key whose bit-length isn't a
+    // multiple of 8 (e.g. an imported 2049-bit RSA modulus) the floor
+    // would reject the only `k` value that would actually round-trip.
+    // `em_bits = key_bits - 1` per RFC 8017 § 8.1.1 also needs the
+    // actual modulus bit-length.
+    let key_bits = n_params.modulus().as_ref().bits() as usize;
     if k != key_bits.div_ceil(8) {
         return Err(Error::InvalidArguments);
     }

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -756,6 +756,20 @@ mod private_op_tests {
         ModMathParams::<SmallUCt, Ct>::new(SmallUCt::from(35u8)).unwrap()
     }
 
+    // A 512-bit odd modulus used by the `sign_into` defensive-error
+    // tests below — they need the actual modulus bit-length (checked
+    // by `sign_into` since the codex-P2 fix) to match `SMALL_K * 8`
+    // so `k` passes the up-front width check and the specific error
+    // path (small buffer, wrong hash length, etc.) is what fires.
+    // Value is `2^511 + 1`: MSB set, LSB=1 (odd).
+    fn toy_params_wide() -> ModMathParams<SmallUCt, Ct> {
+        let mut bytes = [0u8; 64];
+        bytes[0] = 0x80;
+        bytes[63] = 0x01;
+        let n = <SmallUCt as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&bytes).unwrap();
+        ModMathParams::<SmallUCt, Ct>::new(n).unwrap()
+    }
+
     #[test]
     fn rsa_private_op_round_trip_heapless_ct() {
         let n_params = toy_params();
@@ -970,7 +984,7 @@ mod private_op_tests {
     #[test]
     fn pkcs1v15_sign_into_rejects_small_sig_storage() {
         use crate::algorithms::pkcs1v15::sign_into;
-        let n_params = toy_params();
+        let n_params = toy_params_wide();
         let (d, e) = dummy_de();
         let mut em = [0u8; SMALL_K];
         let mut sig = [0u8; SMALL_K - 1]; // one byte short
@@ -992,7 +1006,7 @@ mod private_op_tests {
         // prefix + hashed + 11 > k → `pkcs1v15_sign_pad_into` returns
         // MessageTooLong. Confirms errors from the padding step bubble up.
         use crate::algorithms::pkcs1v15::sign_into;
-        let n_params = toy_params();
+        let n_params = toy_params_wide();
         let (d, e) = dummy_de();
         let mut em = [0u8; SMALL_K];
         let mut sig = [0u8; SMALL_K];
@@ -1015,7 +1029,7 @@ mod private_op_tests {
         use crate::algorithms::pss::sign_into;
         use digest::Digest;
         use sha1::Sha1;
-        let n_params = toy_params();
+        let n_params = toy_params_wide();
         let (d, e) = dummy_de();
         let mut em = [0u8; SMALL_K];
         let mut sig = [0u8; SMALL_K];
@@ -1039,7 +1053,7 @@ mod private_op_tests {
         use crate::algorithms::pss::sign_into;
         use digest::Digest;
         use sha1::Sha1;
-        let n_params = toy_params();
+        let n_params = toy_params_wide();
         let (d, e) = dummy_de();
         let mut em = [0u8; SMALL_K];
         let mut sig = [0u8; SMALL_K - 1];
@@ -1063,7 +1077,7 @@ mod private_op_tests {
         use crate::algorithms::pss::sign_into;
         use digest::Digest;
         use sha1::Sha1;
-        let n_params = toy_params();
+        let n_params = toy_params_wide();
         let (d, e) = dummy_de();
         // em_bits = key_bits - 1 = 511 → em_len = 64. Pass 63 to fail.
         let mut em = [0u8; SMALL_K - 1];
@@ -1090,7 +1104,7 @@ mod private_op_tests {
         use crate::algorithms::pss::sign_into;
         use digest::Digest;
         use sha1::Sha1;
-        let n_params = toy_params();
+        let n_params = toy_params_wide();
         let (d, e) = dummy_de();
         let mut em = [0u8; SMALL_K];
         let mut sig = [0u8; SMALL_K];
@@ -1107,6 +1121,63 @@ mod private_op_tests {
             &mut sig,
         );
         assert!(matches!(result, Err(Error::InputNotHashed)));
+    }
+
+    // Regression for the codex-P2 fix — `sign_into`'s `k` check must
+    // use the actual modulus bit-length, not the container's
+    // `bits_precision()`, otherwise a shorter modulus stored in a
+    // wider container spuriously rejects the only valid `k`.
+    #[test]
+    fn pkcs1v15_sign_into_k_uses_modulus_bits_not_container() {
+        use crate::algorithms::pkcs1v15::sign_into;
+        // 128-byte (1024-bit) container storing a ~512-bit modulus.
+        type WideUCt = FixedUInt<u8, 128, Ct>;
+        let mut mod_bytes = [0u8; 128];
+        mod_bytes[64] = 0x80; // MSB of the low 512 bits
+        mod_bytes[127] = 0x01; // LSB odd
+        let n = <WideUCt as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&mod_bytes).unwrap();
+        let n_params = ModMathParams::<WideUCt, Ct>::new(n).unwrap();
+        let d = wrap_value(WideUCt::from(29u8));
+        let e = wrap_value(WideUCt::from(5u8));
+
+        const CORRECT_K: usize = 64; // 512 modulus bits div_ceil 8
+        const CONTAINER_K: usize = 128; // what `bits_precision()` would say
+
+        // Old buggy behavior: k=64 would return InvalidArguments because
+        // it didn't match container width. Post-fix: k=64 passes the
+        // width check (and only afterwards fails on the toy (d, e)).
+        let mut em = [0u8; CORRECT_K];
+        let mut sig = [0u8; CORRECT_K];
+        let result = sign_into(
+            &n_params,
+            &d,
+            &e,
+            &[],
+            &[0u8; 20],
+            CORRECT_K,
+            &mut em,
+            &mut sig,
+        );
+        assert!(
+            !matches!(result, Err(Error::InvalidArguments)),
+            "correct k (= modulus_bits.div_ceil(8)) must pass the width check, got {:?}",
+            result
+        );
+
+        // Container-width k must be rejected — that's the whole point.
+        let mut em = [0u8; CONTAINER_K];
+        let mut sig = [0u8; CONTAINER_K];
+        let result = sign_into(
+            &n_params,
+            &d,
+            &e,
+            &[],
+            &[0u8; 20],
+            CONTAINER_K,
+            &mut em,
+            &mut sig,
+        );
+        assert!(matches!(result, Err(Error::InvalidArguments)));
     }
 
     // ─── Phase 1 trait surgery: GenericPrivateKeyParts smoke tests ──────


### PR DESCRIPTION
## Summary

Both `pkcs1v15::sign_into` and `pss::sign_into` guarded with `k != n_params.bits_precision().div_ceil(8)`. `bits_precision()` returns the container width, not the actual modulus bit-length, so a shorter modulus stored in a wider integer type (e.g. a 1024-bit RSA key on `U2048`) spuriously rejected the only valid `k` — the same value `PublicKeyParts::size()` reports.

Switched to `n_params.modulus().as_ref().bits().div_ceil(8)`, matching what the verify side already does (`src/pss.rs:166`: `pub_key.n().bits() as _`). For pss, `em_bits = key_bits - 1` per RFC 8017 § 8.1.1 also picks up the fix.

Raised by chatgpt-codex-connector on PR #25 ([`#3488851663`](https://github.com/kaidokert/RSA/pull/25#discussion_r3488851663)).

## Test updates

- Defensive-error tests for `sign_into` used a toy modulus (35, ~6 bits) in a 512-bit container and expected `k = 64` to pass the width check. That worked because the old check used container width; post-fix, those tests need a modulus whose actual bit-length matches `k * 8`. New helper `toy_params_wide()` returns a 512-bit odd modulus (`2^511 + 1`); the affected defensive tests use it.
- New positive regression `pkcs1v15_sign_into_k_uses_modulus_bits_not_container` sets up a 128-byte container storing a ~512-bit modulus and asserts (a) `k = 64` (actual modulus bits) passes the width check; (b) `k = 128` (what old buggy code demanded) is rejected as `InvalidArguments`.

## Test plan
- [x] `cargo check` (default)
- [x] `cargo check --no-default-features --features modmath`
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo test --lib` (97, was 96)
- [x] `cargo test --all-features --tests` (17)
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Adjust RSA signing routines to derive signature length from the actual modulus bit-length instead of the container width and add coverage to prevent regressions.

Bug Fixes:
- Fix pkcs1v15::sign_into and pss::sign_into rejecting valid k values when the RSA modulus is shorter than its integer container by basing k on the modulus bit-length rather than bits_precision().

Tests:
- Introduce a wide toy modulus helper for defensive sign_into tests so their expected error paths still execute under the corrected width check.
- Add a regression test ensuring pkcs1v15::sign_into accepts k equal to the modulus-derived length and rejects k equal to the container width.