### PR TITLE
Block encrypt on NCT public keys at compile time

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -542,13 +542,19 @@ where
     M: ModulusParams<Modulus = T>,
 {
     /// Encrypt the given message.
+    ///
+    /// Bound `M: CtModulusParams` — `NctPublicKey`-derived keys can't
+    /// reach this entry point.
     #[cfg(feature = "alloc")]
     pub fn encrypt<R: CryptoRng + ?Sized, P: PaddingScheme>(
         &self,
         rng: &mut R,
         padding: P,
         msg: &[u8],
-    ) -> Result<Vec<u8>> {
+    ) -> Result<Vec<u8>>
+    where
+        M: crate::traits::modular::CtModulusParams,
+    {
         padding.encrypt(rng, self, msg)
     }
 

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -557,6 +557,13 @@ impl<T: ModMathIntCt> ModulusParams for ModMathParams<T, Ct> {
     }
 }
 
+// Opt the Ct personality into the CT-encrypt gate. Deliberately no
+// impl for `ModMathParams<T, Nct>` — Nct exponentiation is vartime in
+// the base, so `NctPublicKey`-derived encrypting keys fail the encrypt
+// trait bound at compile time. See
+// [`crate::traits::modular::CtModulusParams`].
+impl<T: ModMathIntCt> crate::traits::modular::CtModulusParams for ModMathParams<T, Ct> {}
+
 #[cfg(test)]
 #[cfg(all(feature = "alloc", feature = "private-key"))]
 mod tests {

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -561,7 +561,11 @@ impl<T: ModMathIntCt> ModulusParams for ModMathParams<T, Ct> {
 // impl for `ModMathParams<T, Nct>` — Nct exponentiation is vartime in
 // the base, so `NctPublicKey`-derived encrypting keys fail the encrypt
 // trait bound at compile time. See
-// [`crate::traits::modular::CtModulusParams`].
+// `crate::traits::modular::CtModulusParams`.
+impl<T: ModMathIntCt> crate::traits::modular::sealed::CtModulusParamsSealed
+    for ModMathParams<T, Ct>
+{
+}
 impl<T: ModMathIntCt> crate::traits::modular::CtModulusParams for ModMathParams<T, Ct> {}
 
 #[cfg(test)]

--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -192,6 +192,7 @@ where
         Rng: TryCryptoRng + ?Sized,
         T: UnsignedModularInt,
         K: PublicKeyParts<T>,
+        K::MontyParams: crate::traits::modular::CtModulusParams,
     {
         let em = oaep_encrypt(
             rng,
@@ -292,6 +293,7 @@ where
     D: digest::Digest,
     MGD: digest::Digest + digest::FixedOutputReset,
     K: crate::traits::PublicKeyParts<T>,
+    K::MontyParams: crate::traits::modular::CtModulusParams,
     T: crate::traits::UnsignedModularInt,
 {
     let padded_len = pub_key.size();

--- a/src/oaep/encrypting_key.rs
+++ b/src/oaep/encrypting_key.rs
@@ -93,7 +93,7 @@ where
     D: Digest,
     MGD: Digest + FixedOutputReset,
     T: UnsignedModularInt,
-    M: ModulusParams<Modulus = T> + CtModulusParams,
+    M: CtModulusParams<Modulus = T>,
 {
     fn encrypt_with_rng_into<'a, R: TryCryptoRng + ?Sized>(
         &self,

--- a/src/oaep/encrypting_key.rs
+++ b/src/oaep/encrypting_key.rs
@@ -1,7 +1,10 @@
 use super::encrypt_digest_into;
 #[cfg(not(feature = "alloc"))]
 use super::Label;
-use crate::traits::{modular::ModulusParams, PublicKeyParts, UnsignedModularInt};
+use crate::traits::{
+    modular::{CtModulusParams, ModulusParams},
+    PublicKeyParts, UnsignedModularInt,
+};
 use crate::{traits::RandomizedEncryptor, GenericRsaPublicKey, Result};
 #[cfg(feature = "alloc")]
 use alloc::{boxed::Box, vec::Vec};
@@ -81,12 +84,16 @@ where
     }
 }
 
+// `M: CtModulusParams` — encrypt on an NCT-personality key would
+// silently downgrade the plaintext (secret!) to vartime work; refuse
+// to compile in that case. Signature verification stays personality-
+// agnostic.
 impl<D, MGD, T, M> RandomizedEncryptor for GenericEncryptingKey<D, MGD, T, M>
 where
     D: Digest,
     MGD: Digest + FixedOutputReset,
     T: UnsignedModularInt,
-    M: ModulusParams<Modulus = T>,
+    M: ModulusParams<Modulus = T> + CtModulusParams,
 {
     fn encrypt_with_rng_into<'a, R: TryCryptoRng + ?Sized>(
         &self,

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -97,6 +97,7 @@ impl Pkcs1v15Encrypt {
         R: TryCryptoRng + ?Sized,
         T: UnsignedModularInt,
         K: PublicKeyParts<T>,
+        K::MontyParams: crate::traits::modular::CtModulusParams,
     {
         let padded_len = pub_key.size();
         let em = pkcs1v15_encrypt_pad_into(rng, msg, padded_len, storage)?;
@@ -116,6 +117,7 @@ fn encrypt<R: TryCryptoRng + ?Sized, K, T>(rng: &mut R, pub_key: &K, msg: &[u8])
 where
     T: UnsignedModularInt,
     K: PublicKeyParts<T>,
+    K::MontyParams: crate::traits::modular::CtModulusParams,
 {
     let mut storage = vec![0u8; pub_key.size()];
     let ciphertext = Pkcs1v15Encrypt.encrypt_into(rng, pub_key, msg, &mut storage)?;
@@ -185,6 +187,7 @@ impl PaddingScheme for Pkcs1v15Encrypt {
         Rng: TryCryptoRng + ?Sized,
         T: UnsignedModularInt,
         K: PublicKeyParts<T>,
+        K::MontyParams: crate::traits::modular::CtModulusParams,
     {
         let mut storage = vec![0u8; pub_key.size()];
         let ciphertext = self.encrypt_into(rng, pub_key, msg, &mut storage)?;
@@ -295,6 +298,7 @@ where
     R: TryCryptoRng + ?Sized,
     T: UnsignedModularInt,
     K: PublicKeyParts<T>,
+    K::MontyParams: crate::traits::modular::CtModulusParams,
 {
     Pkcs1v15Encrypt.encrypt_into(rng, pub_key, msg, storage)
 }

--- a/src/pkcs1v15/encrypting_key.rs
+++ b/src/pkcs1v15/encrypting_key.rs
@@ -57,7 +57,7 @@ where
 impl<T, M> RandomizedEncryptor for GenericEncryptingKey<T, M>
 where
     T: UnsignedModularInt,
-    M: ModulusParams<Modulus = T> + CtModulusParams,
+    M: CtModulusParams<Modulus = T>,
 {
     fn encrypt_with_rng_into<'a, R: rand_core::TryCryptoRng + ?Sized>(
         &self,

--- a/src/pkcs1v15/encrypting_key.rs
+++ b/src/pkcs1v15/encrypting_key.rs
@@ -1,7 +1,10 @@
 use super::encrypt_into;
 use crate::{
     key::GenericRsaPublicKey,
-    traits::{modular::ModulusParams, PublicKeyParts, RandomizedEncryptor, UnsignedModularInt},
+    traits::{
+        modular::{CtModulusParams, ModulusParams},
+        PublicKeyParts, RandomizedEncryptor, UnsignedModularInt,
+    },
     Result,
 };
 #[cfg(feature = "alloc")]
@@ -47,10 +50,14 @@ where
     }
 }
 
+// `M: CtModulusParams` — encrypt on an NCT-personality key would
+// silently downgrade the plaintext (secret!) to vartime work; refuse
+// to compile in that case. Signature verification stays personality-
+// agnostic.
 impl<T, M> RandomizedEncryptor for GenericEncryptingKey<T, M>
 where
     T: UnsignedModularInt,
-    M: ModulusParams<Modulus = T>,
+    M: ModulusParams<Modulus = T> + CtModulusParams,
 {
     fn encrypt_with_rng_into<'a, R: rand_core::TryCryptoRng + ?Sized>(
         &self,

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -347,6 +347,25 @@ pub trait ModulusParams: Sized {
     fn bits_precision(&self) -> u32;
 }
 
+/// Marker trait for [`ModulusParams`] backends whose Montgomery
+/// exponentiation is constant-time in the base (secret) value.
+///
+/// Bound the public-key encryption path on this so plaintext (which
+/// **is** secret) can't be silently exposed to variable-time work.
+/// Signature verification stays unbounded — the "base" there is the
+/// public signature, so vartime is fine.
+///
+/// **Implemented for [`crypto_bigint::modular::BoxedMontyParams`]**
+/// unconditionally (its `BoxedMontyForm` is CT internally). Heapless
+/// backends opt in on the CT-personality substitution only — see
+/// [`crate::modmath_support::ModMathParams`], which impls this on
+/// `<T, Ct>` but *not* on `<T, Nct>`, so `NctPublicKey`-derived
+/// encrypting keys fail to compile the encrypt trait bound.
+pub trait CtModulusParams: ModulusParams {}
+
+#[cfg(feature = "alloc")]
+impl CtModulusParams for BoxedMontyParams {}
+
 #[cfg(feature = "alloc")]
 impl ModulusParams for BoxedMontyParams {
     type Modulus = BoxedUint;

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -347,22 +347,48 @@ pub trait ModulusParams: Sized {
     fn bits_precision(&self) -> u32;
 }
 
+pub(crate) mod sealed {
+    /// Prevents external crates from implementing
+    /// [`super::CtModulusParams`] on backends we haven't audited —
+    /// see the security note on that trait.
+    pub trait CtModulusParamsSealed {}
+}
+
 /// Marker trait for [`ModulusParams`] backends whose Montgomery
-/// exponentiation is constant-time in the base (secret) value.
+/// exponentiation itself is constant-time in the base value.
 ///
 /// Bound the public-key encryption path on this so plaintext (which
-/// **is** secret) can't be silently exposed to variable-time work.
+/// **is** secret) can't be routed through a vartime `pow_bounded_exp`.
 /// Signature verification stays unbounded — the "base" there is the
 /// public signature, so vartime is fine.
 ///
-/// **Implemented for [`crypto_bigint::modular::BoxedMontyParams`]**
-/// unconditionally (its `BoxedMontyForm` is CT internally). Heapless
-/// backends opt in on the CT-personality substitution only — see
-/// [`crate::modmath_support::ModMathParams`], which impls this on
-/// `<T, Ct>` but *not* on `<T, Nct>`, so `NctPublicKey`-derived
-/// encrypting keys fail to compile the encrypt trait bound.
-pub trait CtModulusParams: ModulusParams {}
+/// The trait is sealed — only backends impl'd by this crate can opt
+/// in. Downstream crates cannot claim the guarantee for their own
+/// backends without inviting the exact side-channel this bound is
+/// meant to keep out.
+///
+/// # Backends
+///
+/// - Under `feature = "alloc"`, `crypto_bigint::modular::BoxedMontyParams`
+///   opts in. Its `BoxedMontyForm::pow_bounded_exp` is CT in the
+///   base. **Caveat:** the pre-exponentiation conversion (see
+///   `IntoMontyForm::from_value` for `BoxedMontyForm`) still uses a
+///   vartime reduction (`BoxedUint::rem_vartime`) inherited from
+///   upstream `RustCrypto/RSA`. Callers requiring rigorous CT
+///   guarantees over the whole encrypt chain should use the no-alloc
+///   modmath backend at the `Ct` personality (below). The alloc
+///   impl is included primarily for API-surface compatibility with
+///   upstream and to keep the default alloc encrypt path functional.
+/// - Under `feature = "modmath"`, `ModMathParams<T, Ct>` opts in —
+///   the no-alloc CT-personality substitution, honestly CT top to
+///   bottom.
+/// - `ModMathParams<T, Nct>` **deliberately does not** opt in;
+///   `NctPublicKey`-derived encrypting keys fail the encrypt trait
+///   bound at compile time.
+pub trait CtModulusParams: ModulusParams + sealed::CtModulusParamsSealed {}
 
+#[cfg(feature = "alloc")]
+impl sealed::CtModulusParamsSealed for BoxedMontyParams {}
 #[cfg(feature = "alloc")]
 impl CtModulusParams for BoxedMontyParams {}
 

--- a/src/traits/padding.rs
+++ b/src/traits/padding.rs
@@ -8,6 +8,7 @@ use rand_core::TryCryptoRng;
 use crate::errors::Result;
 #[cfg(feature = "private-key")]
 use crate::key::RsaPrivateKey;
+use crate::traits::modular::CtModulusParams;
 use crate::traits::{PublicKeyParts, UnsignedModularInt};
 
 /// Padding scheme used for encryption.
@@ -25,12 +26,18 @@ pub trait PaddingScheme {
     ) -> Result<Vec<u8>>;
 
     /// Encrypt the given message using the given public key.
+    ///
+    /// Bound `K::MontyParams: CtModulusParams` — `NctPublicKey`-derived
+    /// keys can't reach this entry point, matching the
+    /// [`crate::traits::RandomizedEncryptor`] gate on
+    /// `GenericEncryptingKey`.
     #[cfg(feature = "alloc")]
     fn encrypt<Rng, K, T>(self, rng: &mut Rng, pub_key: &K, msg: &[u8]) -> Result<Vec<u8>>
     where
         Rng: TryCryptoRng + ?Sized,
         T: UnsignedModularInt,
-        K: PublicKeyParts<T>;
+        K: PublicKeyParts<T>,
+        K::MontyParams: CtModulusParams;
 }
 
 /// Digital signature scheme.


### PR DESCRIPTION
## Summary

`public_key_from_be_bytes` (NCT) and `public_key_ct_from_be_bytes` (CT) produced encrypting keys that differed only in the `Personality` type parameter, and nothing prevented a caller from running `.encrypt(...)` on an NCT-derived one — which silently downgrades the private-key operation on the plaintext (a **secret**) to variable-time work.

New marker trait `CtModulusParams: ModulusParams` in `traits/modular.rs`:

- Impl'd unconditionally for `crypto_bigint::modular::BoxedMontyParams` — its `BoxedMontyForm` exponentiation is CT internally.
- Impl'd for `ModMathParams<T, Ct>` in `modmath_support.rs`.
- **Not** impl'd for `ModMathParams<T, Nct>` — any encrypting key built from an NCT modulus fails to compile the encrypt trait bound.

Both `RandomizedEncryptor for GenericEncryptingKey<T, M>` impls (pkcs1v15 and oaep) now require `M: CtModulusParams`. Verify side stays unbounded — the "base" there is the public signature, so vartime is safe.

CLAUDE.md follow-up ("Block encrypt on NCT public keys") — closes the silent-vartime footgun.

## Test plan
- [x] `cargo check` (default)
- [x] `cargo check --no-default-features --features modmath`
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo test --lib` (97)
- [x] `cargo test --all-features --tests` (17)
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Enforce that RSA public-key encryption only uses constant-time modular backends to prevent plaintext from being processed with variable-time operations.

Bug Fixes:
- Prevent use of non-constant-time (NCT) modulus parameters for RSA public-key encryption, eliminating a silent downgrade of secret-dependent work to variable-time behavior.

Enhancements:
- Introduce a CtModulusParams marker trait to distinguish constant-time modular backends and gate encryption implementations on this trait.
- Opt the constant-time ModMathParams Ct personality into the new CtModulusParams trait while leaving Nct excluded to maintain compile-time safety guarantees.