### PR TITLE
Phase 5: drop legacy PrivateKeyParts, rename generic

### DIFF
--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -18,7 +18,7 @@ use zeroize::Zeroize;
 #[cfg(not(feature = "private-key"))]
 use crate::traits::keys::PublicKeyParts;
 #[cfg(feature = "private-key")]
-use crate::traits::keys::{GenericPrivateKeyParts, PublicKeyParts};
+use crate::traits::keys::{PrivateKeyParts, PublicKeyParts};
 use crate::{
     errors::{Error, Result},
     traits::{
@@ -60,10 +60,10 @@ pub fn rsa_decrypt<R: TryCryptoRng + ?Sized, K>(
     c: &BoxedUint,
 ) -> Result<BoxedUint>
 where
-    K: GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
+    K: PrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
 {
     let n = priv_key.n();
-    let d = GenericPrivateKeyParts::d(priv_key);
+    let d = PrivateKeyParts::d(priv_key);
 
     if c.bits_precision() != n.as_ref().bits_precision() {
         return Err(Error::Decryption);
@@ -86,20 +86,20 @@ where
         c.try_resize(bits).ok_or(Error::Internal)?
     };
 
-    // Bind once — `GenericPrivateKeyParts::primes` default returns `&[]`,
+    // Bind once — `PrivateKeyParts::primes` default returns `&[]`,
     // so a key that overrides the CRT accessors but not `primes` could
     // otherwise reach the CRT branch and panic on `[0]`/`[1]`. The
     // `primes.len() >= 2` guard below makes that impossible regardless
     // of how the trait is implemented.
-    let primes = GenericPrivateKeyParts::primes(priv_key);
+    let primes = PrivateKeyParts::primes(priv_key);
     let is_multiprime = primes.len() > 2;
 
     let m = match (
-        GenericPrivateKeyParts::dp(priv_key),
-        GenericPrivateKeyParts::dq(priv_key),
-        GenericPrivateKeyParts::qinv(priv_key),
-        GenericPrivateKeyParts::p_params(priv_key),
-        GenericPrivateKeyParts::q_params(priv_key),
+        PrivateKeyParts::dp(priv_key),
+        PrivateKeyParts::dq(priv_key),
+        PrivateKeyParts::qinv(priv_key),
+        PrivateKeyParts::p_params(priv_key),
+        PrivateKeyParts::q_params(priv_key),
     ) {
         (Some(dp), Some(dq), Some(qinv), Some(p_params), Some(q_params))
             if !is_multiprime && primes.len() >= 2 =>
@@ -191,7 +191,7 @@ pub fn rsa_decrypt_and_check<R: TryCryptoRng + ?Sized, K>(
     c: &BoxedUint,
 ) -> Result<BoxedUint>
 where
-    K: GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
+    K: PrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
 {
     let m = rsa_decrypt(rng, priv_key, c)?;
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -6,7 +6,7 @@
 #![cfg(feature = "encoding")]
 
 use crate::{
-    traits::{GenericPrivateKeyParts, PublicKeyParts},
+    traits::{PrivateKeyParts, PublicKeyParts},
     RsaPrivateKey, RsaPublicKey,
 };
 use core::convert::{TryFrom, TryInto};

--- a/src/key.rs
+++ b/src/key.rs
@@ -35,11 +35,8 @@ use crate::algorithms::rsa::{
 use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
 use crate::traits::keys::PublicKeyParts;
-#[cfg(feature = "private-key")]
-#[allow(deprecated)]
-use crate::traits::keys::{CrtValue, PrivateKeyParts};
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-use crate::traits::keys::{GenericPrivateKeyParts, RawPrivateKeyConstructible};
+use crate::traits::keys::{PrivateKeyParts, RawPrivateKeyConstructible};
 use crate::traits::{
     modular::ModulusParams, NonZero, PaddingScheme, SignatureScheme, UnsignedModularInt,
 };
@@ -103,7 +100,7 @@ where
 ///
 /// Holds the public components plus the secret exponent `d`. Mirrors
 /// [`GenericRsaPublicKey`] in shape; satisfies both [`PublicKeyParts<T>`]
-/// (via delegation to the inner pubkey) and [`GenericPrivateKeyParts<T>`]
+/// (via delegation to the inner pubkey) and [`PrivateKeyParts<T>`]
 /// — the Montgomery parameter type `M` comes through `PublicKeyParts`'s
 /// `MontyParams` associated type.
 ///
@@ -263,7 +260,7 @@ where
 }
 
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-impl<T, M> GenericPrivateKeyParts<T> for GenericRsaPrivateKey<T, M>
+impl<T, M> PrivateKeyParts<T> for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
     M: ModulusParams<Modulus = T>,
@@ -1033,44 +1030,6 @@ impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     }
 }
 
-// Kept impl'd for backwards compat with external consumers bounding on
-// the deprecated trait. New code should use `GenericPrivateKeyParts`.
-#[cfg(feature = "private-key")]
-#[allow(deprecated)]
-impl PrivateKeyParts for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
-    fn d(&self) -> &BoxedUint {
-        &self.d
-    }
-
-    fn primes(&self) -> &[BoxedUint] {
-        &self.primes
-    }
-
-    fn dp(&self) -> Option<&BoxedUint> {
-        self.precomputed.as_ref().map(|p| &p.dp)
-    }
-
-    fn dq(&self) -> Option<&BoxedUint> {
-        self.precomputed.as_ref().map(|p| &p.dq)
-    }
-
-    fn qinv(&self) -> Option<&BoxedMontyForm> {
-        self.precomputed.as_ref().map(|p| &p.qinv)
-    }
-
-    fn crt_values(&self) -> Option<&[CrtValue]> {
-        None
-    }
-
-    fn p_params(&self) -> Option<&BoxedMontyParams> {
-        self.precomputed.as_ref().map(|p| &p.p_params)
-    }
-
-    fn q_params(&self) -> Option<&BoxedMontyParams> {
-        self.precomputed.as_ref().map(|p| &p.q_params)
-    }
-}
-
 /// Check that the public key is well formed and has an exponent within acceptable bounds.
 #[inline]
 #[cfg(feature = "alloc")]
@@ -1222,7 +1181,7 @@ impl<'de> Deserialize<'de> for RsaPrivateKey {
 mod tests {
     use super::*;
     use crate::algorithms::rsa::{rsa_decrypt_and_check, rsa_encrypt};
-    use crate::traits::{GenericPrivateKeyParts, PublicKeyParts};
+    use crate::traits::{PrivateKeyParts, PublicKeyParts};
 
     use hex_literal::hex;
     use rand::rngs::ChaCha8Rng;
@@ -1258,7 +1217,7 @@ mod tests {
         private_key.validate().expect("invalid private key");
 
         assert!(
-            GenericPrivateKeyParts::d(private_key) < PublicKeyParts::n(private_key).as_ref(),
+            PrivateKeyParts::d(private_key) < PublicKeyParts::n(private_key).as_ref(),
             "private exponent too large"
         );
 
@@ -1552,7 +1511,7 @@ mod tests {
         let ref_key = RsaPrivateKey::from_pkcs8_der(RSA_2048_PRIV_DER).unwrap();
         assert_eq!(ref_key.validate(), Ok(()));
 
-        let primes = GenericPrivateKeyParts::primes(&ref_key).to_vec();
+        let primes = PrivateKeyParts::primes(&ref_key).to_vec();
 
         let exp = PublicKeyParts::e(&ref_key);
         let key = RsaPrivateKey::from_primes(primes, exp.clone())
@@ -1561,19 +1520,10 @@ mod tests {
 
         assert_eq!(PublicKeyParts::n(&key), PublicKeyParts::n(&ref_key));
 
-        assert_eq!(
-            GenericPrivateKeyParts::dp(&key),
-            GenericPrivateKeyParts::dp(&ref_key)
-        );
-        assert_eq!(
-            GenericPrivateKeyParts::dq(&key),
-            GenericPrivateKeyParts::dq(&ref_key)
-        );
+        assert_eq!(PrivateKeyParts::dp(&key), PrivateKeyParts::dp(&ref_key));
+        assert_eq!(PrivateKeyParts::dq(&key), PrivateKeyParts::dq(&ref_key));
 
-        assert_eq!(
-            GenericPrivateKeyParts::d(&key),
-            GenericPrivateKeyParts::d(&ref_key)
-        );
+        assert_eq!(PrivateKeyParts::d(&key), PrivateKeyParts::d(&ref_key));
     }
 
     #[test]
@@ -1584,7 +1534,7 @@ mod tests {
         let ref_key = RsaPrivateKey::from_pkcs8_der(RSA_2048_SP800_PRIV_DER).unwrap();
         assert_eq!(ref_key.validate(), Ok(()));
 
-        let primes = GenericPrivateKeyParts::primes(&ref_key).to_vec();
+        let primes = PrivateKeyParts::primes(&ref_key).to_vec();
         let exp = PublicKeyParts::e(&ref_key);
 
         let key = RsaPrivateKey::from_p_q(primes[0].clone(), primes[1].clone(), exp.clone())
@@ -1593,19 +1543,10 @@ mod tests {
 
         assert_eq!(PublicKeyParts::n(&key), PublicKeyParts::n(&ref_key));
 
-        assert_eq!(
-            GenericPrivateKeyParts::dp(&key),
-            GenericPrivateKeyParts::dp(&ref_key)
-        );
-        assert_eq!(
-            GenericPrivateKeyParts::dq(&key),
-            GenericPrivateKeyParts::dq(&ref_key)
-        );
+        assert_eq!(PrivateKeyParts::dp(&key), PrivateKeyParts::dp(&ref_key));
+        assert_eq!(PrivateKeyParts::dq(&key), PrivateKeyParts::dq(&ref_key));
 
-        assert_eq!(
-            GenericPrivateKeyParts::d(&key),
-            GenericPrivateKeyParts::d(&ref_key)
-        );
+        assert_eq!(PrivateKeyParts::d(&key), PrivateKeyParts::d(&ref_key));
     }
 
     #[test]
@@ -1649,7 +1590,7 @@ mod tests {
         let key_with_large_exp = key_with_large_exp.unwrap();
         assert_eq!(PublicKeyParts::e(&key_with_large_exp), &large_e);
         assert_eq!(PublicKeyParts::n(&key_with_large_exp).as_ref(), &n);
-        assert_eq!(GenericPrivateKeyParts::d(&key_with_large_exp), &d);
+        assert_eq!(PrivateKeyParts::d(&key_with_large_exp), &d);
 
         // Verify that the key is still cryptographically valid (de ≡ 1 mod λ(n))
         // by checking that validation with skip_exponent_size passes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,8 +270,6 @@ pub use sha2;
 
 #[cfg(feature = "alloc")]
 pub use crate::key::RsaPublicKey;
-#[cfg(all(feature = "alloc", feature = "private-key"))]
-pub use crate::traits::keys::CrtValue;
 pub use crate::{
     errors::{Error, Result},
     key::GenericRsaPublicKey,

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1191,7 +1191,7 @@ mod private_op_tests {
         assert!(matches!(result, Err(Error::InvalidArguments)));
     }
 
-    // ─── Phase 1 trait surgery: GenericPrivateKeyParts smoke tests ──────
+    // ─── Phase 1 trait surgery: PrivateKeyParts smoke tests ──────
 
     #[test]
     fn pkcs1v15_signing_key_round_trip_2048_sha1() {
@@ -1399,11 +1399,11 @@ mod private_op_tests {
     #[test]
     fn generic_rsa_private_key_satisfies_traits() {
         // Compile-time assertion: GenericRsaPrivateKey<SmallUCt, ModMathParams<SmallUCt, Ct>>
-        // satisfies both PublicKeyParts and GenericPrivateKeyParts at the
+        // satisfies both PublicKeyParts and PrivateKeyParts at the
         // matching (T, M) substitution. The fn-bound dance below is the
         // standard "type-satisfies-trait" check.
         use crate::key::GenericRsaPrivateKey;
-        use crate::traits::keys::{GenericPrivateKeyParts, PublicKeyParts};
+        use crate::traits::keys::{PrivateKeyParts, PublicKeyParts};
         fn assert_pub_parts<K, T>(_: &K)
         where
             T: UnsignedModularInt,
@@ -1413,7 +1413,7 @@ mod private_op_tests {
         fn assert_priv_parts<K, T>(_: &K)
         where
             T: UnsignedModularInt,
-            K: GenericPrivateKeyParts<T>,
+            K: PrivateKeyParts<T>,
         {
         }
 
@@ -1427,10 +1427,7 @@ mod private_op_tests {
         assert_priv_parts::<_, ModMathValue<SmallUCt>>(&key);
 
         // Round-trip: accessors return the values we constructed it with.
-        assert_eq!(
-            GenericPrivateKeyParts::d(&key),
-            &wrap_value(SmallUCt::from(29u8))
-        );
+        assert_eq!(PrivateKeyParts::d(&key), &wrap_value(SmallUCt::from(29u8)));
         assert_eq!(key.as_public().e(), &wrap_value(SmallUCt::from(5u8)));
     }
 }

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -176,7 +176,7 @@ where
         let k = self.inner.size();
         sign_into(
             self.inner.n_params(),
-            crate::traits::keys::GenericPrivateKeyParts::d(&self.inner),
+            crate::traits::keys::PrivateKeyParts::d(&self.inner),
             self.inner.e(),
             self.prefix.as_ref(),
             digest.as_ref(),
@@ -205,7 +205,7 @@ where
         let k = self.inner.size();
         sign_into(
             self.inner.n_params(),
-            crate::traits::keys::GenericPrivateKeyParts::d(&self.inner),
+            crate::traits::keys::PrivateKeyParts::d(&self.inner),
             self.inner.e(),
             self.prefix.as_ref(),
             prehash,

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -198,7 +198,7 @@ where
         let mut hash = D::new();
         sign_into(
             self.inner.n_params(),
-            crate::traits::keys::GenericPrivateKeyParts::d(&self.inner),
+            crate::traits::keys::PrivateKeyParts::d(&self.inner),
             self.inner.e(),
             prehash,
             salt,
@@ -232,7 +232,7 @@ where
         let mut hash = D::new();
         sign_into(
             self.inner.n_params(),
-            crate::traits::keys::GenericPrivateKeyParts::d(&self.inner),
+            crate::traits::keys::PrivateKeyParts::d(&self.inner),
             self.inner.e(),
             prehash,
             salt,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,9 +7,6 @@ mod padding;
 
 pub use encryption::{Decryptor, EncryptingKeypair, RandomizedDecryptor, RandomizedEncryptor};
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-pub use keys::GenericPrivateKeyParts;
-#[cfg(feature = "private-key")]
-#[allow(deprecated)]
 pub use keys::PrivateKeyParts;
 pub use keys::PublicKeyParts;
 pub use modular::{FixedWidthUnsignedInt, IntegerResize, NonZero, Odd, UnsignedModularInt};

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -2,12 +2,6 @@
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-#[cfg(feature = "private-key")]
-use crypto_bigint::{
-    modular::{BoxedMontyForm, BoxedMontyParams},
-    BoxedUint,
-};
-use zeroize::Zeroize;
 
 use crate::traits::{modular::ModulusParams, NonZero, UnsignedModularInt};
 
@@ -80,8 +74,8 @@ pub trait PublicKeyParts<T: UnsignedModularInt> {
     }
 }
 
-/// Generic components of an RSA private key — minimal trait for the
-/// heapless / wip-private-key port.
+/// Components of an RSA private key — generic over the integer /
+/// Montgomery-parameter backend.
 ///
 /// Mirrors [`PublicKeyParts`] in shape: generic over the integer
 /// type `T`, no concrete dependency on `BoxedUint`/`BoxedMontyParams`.
@@ -91,14 +85,8 @@ pub trait PublicKeyParts<T: UnsignedModularInt> {
 /// can't reach them. Default impls return `None` so a generic key
 /// without precomputed CRT values (e.g. [`GenericRsaPrivateKey`])
 /// satisfies the trait with the minimum.
-///
-/// The legacy [`PrivateKeyParts`] (alloc-bound, `BoxedUint`-concrete)
-/// is bridged to this trait via a blanket impl, so any existing
-/// `K: PrivateKeyParts` value also satisfies
-/// `GenericPrivateKeyParts<BoxedUint>` — with the bridge forwarding
-/// the CRT accessors when present.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
-pub trait GenericPrivateKeyParts<T>: PublicKeyParts<T>
+pub trait PrivateKeyParts<T>: PublicKeyParts<T>
 where
     T: UnsignedModularInt,
 {
@@ -141,71 +129,5 @@ where
     #[cfg(feature = "private-key")]
     fn q_params(&self) -> Option<&Self::MontyParams> {
         None
-    }
-}
-
-/// Components of an RSA private key.
-///
-/// **Deprecated** — superseded by [`GenericPrivateKeyParts`], which is
-/// generic over the integer / Montgomery-parameter backend. Existing
-/// `K: PrivateKeyParts` types still work but new code should bound on
-/// `GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>`
-/// instead.
-#[cfg(feature = "private-key")]
-#[deprecated(
-    since = "0.3.0",
-    note = "use `GenericPrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>` (generic over backend) instead; this trait will be removed in a future major version"
-)]
-pub trait PrivateKeyParts: PublicKeyParts<BoxedUint> {
-    /// Returns the private exponent of the key.
-    fn d(&self) -> &BoxedUint;
-
-    /// Returns the prime factors.
-    fn primes(&self) -> &[BoxedUint];
-
-    /// Returns the precomputed dp value, D mod (P-1)
-    fn dp(&self) -> Option<&BoxedUint>;
-
-    /// Returns the precomputed dq value, D mod (Q-1)
-    fn dq(&self) -> Option<&BoxedUint>;
-
-    /// Returns the precomputed qinv value, Q^-1 mod P
-    fn qinv(&self) -> Option<&BoxedMontyForm>;
-
-    /// Returns an iterator over the CRT Values
-    fn crt_values(&self) -> Option<&[CrtValue]>;
-
-    /// Returns the params for `p` if precomputed.
-    fn p_params(&self) -> Option<&BoxedMontyParams>;
-
-    /// Returns the params for `q` if precomputed.
-    fn q_params(&self) -> Option<&BoxedMontyParams>;
-}
-
-/// Contains the precomputed Chinese remainder theorem values.
-#[cfg(feature = "private-key")]
-#[derive(Debug, Clone)]
-pub struct CrtValue {
-    /// D mod (prime - 1)
-    pub(crate) exp: BoxedUint,
-    /// R·Coeff ≡ 1 mod Prime.
-    pub(crate) coeff: BoxedUint,
-    /// product of primes prior to this (inc p and q)
-    pub(crate) r: BoxedUint,
-}
-
-#[cfg(feature = "private-key")]
-impl Zeroize for CrtValue {
-    fn zeroize(&mut self) {
-        self.exp.zeroize();
-        self.coeff.zeroize();
-        self.r.zeroize();
-    }
-}
-
-#[cfg(feature = "private-key")]
-impl Drop for CrtValue {
-    fn drop(&mut self) {
-        self.zeroize();
     }
 }

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -6,7 +6,7 @@ use crypto_bigint::{BoxedUint, CtEq};
 use hex_literal::hex;
 use rsa::{
     pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey},
-    traits::{GenericPrivateKeyParts, PublicKeyParts},
+    traits::{PrivateKeyParts, PublicKeyParts},
     RsaPrivateKey, RsaPublicKey,
 };
 

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -8,7 +8,7 @@ use rsa::{
     pkcs1v15,
     pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey},
     pss,
-    traits::{GenericPrivateKeyParts, PublicKeyParts},
+    traits::{PrivateKeyParts, PublicKeyParts},
     RsaPrivateKey, RsaPublicKey,
 };
 use sha2::Sha256;


### PR DESCRIPTION
## Summary

Completes the shadow-trait migration series started with Fold-1.

- Removes the deprecated `PrivateKeyParts` alloc-bound trait, its `impl` on `GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`, the `CrtValue` struct (only ever referenced by `PrivateKeyParts::crt_values`), and all `#[allow(deprecated)]` scaffolding introduced in Phase 4.
- Renames the generic-backend trait `GenericPrivateKeyParts<T>` back to `PrivateKeyParts<T>` — its original conceptual name, now freed by the removal.

External code that used to bound on `K: PrivateKeyParts` now expresses the same constraint as `K: PrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>`. `crt_values` had no equivalent on the generic trait and is intentionally gone — nothing internal called it and its return `Option<&[CrtValue]>` was always `None` on `GenericRsaPrivateKey` anyway.

## Breaking change

Requires a major version bump at release time. External consumers bounding on the removed `PrivateKeyParts` (or using `CrtValue`) hit a hard compile error — the Phase 4 deprecation warning was their heads-up.

## Diff shape

11 files, +40 / −185. Bulk of the shrink: `src/traits/keys.rs` (−84) losing the legacy trait + CrtValue, `src/key.rs` (−52) losing the impl block.

## Test plan
- [x] `cargo check` (default)
- [x] `cargo check --no-default-features --features modmath`
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo test --lib` (97)
- [x] `cargo test --all-features --tests` (17)
- [x] `cargo test --doc` (6)
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Complete the migration to the generic private-key trait by removing the deprecated alloc-bound private key API and renaming the generic trait back to `PrivateKeyParts`.

Enhancements:
- Rename the generic `GenericPrivateKeyParts<T>` trait to `PrivateKeyParts<T>` throughout the RSA implementation and tests to reflect its role as the primary private-key interface.

Tests:
- Update RSA encryption/decryption, signing, encoding, and test code to depend on the new generic `PrivateKeyParts<T>` trait bounds instead of the removed legacy and `GenericPrivateKeyParts` traits.

Chores:
- Remove the deprecated alloc-specific `PrivateKeyParts` trait, its `CrtValue` helper type, and the compatibility impl on `GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`, simplifying the key traits API surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Broadened RSA private-key support across signing, decryption, and key handling paths.
  * Improved compatibility for builds using private-key-related features.

* **Bug Fixes**
  * Updated RSA operations to use the current private-key accessors, helping ensure consistent behavior when working with private keys.
  * Removed an outdated RSA-related export to keep the public API cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->