### PR TITLE
Switch sign_into to uint_to_zeroizing_be_pad_into

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
 modmath = { version = "0.3.0", optional = true, default-features = false, features = ["wide-mul", "zeroize"] }
-fixed-bigint = { version = "0.3.0", optional = true, default-features = false, features = ["zeroize", "use-unsafe"] }
+fixed-bigint = { version = "0.3.2", optional = true, default-features = false, features = ["zeroize", "use-unsafe"] }
 subtle = { version = "2.6", default-features = false }
 heapless = "0.9"
 
@@ -58,7 +58,7 @@ serde_json = "1.0.138"
 serde = { version = "1.0.184", features = ["derive"] }
 rstest = "0.26.1"
 crypto-bigint = { version = "0.7", default-features = false, features = ["zeroize", "alloc"] }
-fixed-bigint = { version = "0.3.0", default-features = false, features = ["zeroize", "use-unsafe"] }
+fixed-bigint = { version = "0.3.2", default-features = false, features = ["zeroize", "use-unsafe"] }
 
 [[bench]]
 name = "key"

--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -211,11 +211,6 @@ pub fn pkcs1v15_sign_pad_into<'a>(
 /// context. Higher-level callers should hash the input message themselves
 /// and prepend the appropriate digest-algorithm DigestInfo prefix.
 ///
-/// TODO: switch the final serialization step to `uint_to_zeroizing_be_pad_into`
-/// once fixed-bigint provides `Zeroize` for `BytesHolder`. The intermediate
-/// `T::Bytes` produced by `s.to_be_bytes()` carries the just-signed value
-/// briefly on the stack; today it's a soft-leak window, the future zeroizing
-/// path closes it.
 // Consumer (the heapless `SigningKey<D>` wrapper) lands in a later PR.
 #[allow(dead_code)]
 #[allow(clippy::too_many_arguments)] // Composing four byte/integer steps; splitting helps nothing.
@@ -232,6 +227,7 @@ pub fn sign_into<'sig, T, M>(
 ) -> Result<&'sig [u8]>
 where
     T: UnsignedModularInt,
+    T::Bytes: zeroize::Zeroize,
     M: ModulusParams<Modulus = T>,
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
 {
@@ -256,7 +252,7 @@ where
     let em_slice = pkcs1v15_sign_pad_into(prefix, hashed, k, em_storage)?;
     let em = T::try_from_be_bytes_vartime(em_slice)?;
     let s = crate::algorithms::rsa::rsa_private_op_and_check(&em, d, e, n_params)?;
-    crate::algorithms::pad::uint_to_be_pad_into(s, k, sig_storage)
+    crate::algorithms::pad::uint_to_zeroizing_be_pad_into(s, k, sig_storage)
 }
 
 #[inline]

--- a/src/algorithms/pss.rs
+++ b/src/algorithms/pss.rs
@@ -226,11 +226,6 @@ where
 /// `salt`. This is the raw PSS sign primitive — wrap it in a higher-level
 /// `SigningKey<D>` for real use.
 ///
-/// TODO: switch the final serialization to `uint_to_zeroizing_be_pad_into`
-/// once fixed-bigint provides `Zeroize` for `BytesHolder`. The
-/// intermediate `T::Bytes` produced by `s.to_be_bytes()` carries the
-/// just-signed value briefly on the stack; today it's a soft-leak window
-/// the future zeroizing path closes.
 // Consumer (the heapless `pss::SigningKey<D>` wrapper) lands in a later PR.
 #[allow(dead_code)]
 #[allow(clippy::too_many_arguments)] // Composing four byte/integer steps; splitting helps nothing.
@@ -248,6 +243,7 @@ pub fn sign_into<'sig, T, M, D>(
 ) -> Result<&'sig [u8]>
 where
     T: UnsignedModularInt,
+    T::Bytes: zeroize::Zeroize,
     M: ModulusParams<Modulus = T>,
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
     D: Digest + FixedOutputReset,
@@ -278,7 +274,7 @@ where
     let em_slice = emsa_pss_encode_into(m_hash, em_bits, salt, hash, em_storage)?;
     let em = T::try_from_be_bytes_vartime(em_slice)?;
     let s = crate::algorithms::rsa::rsa_private_op_and_check(&em, d, e, n_params)?;
-    crate::algorithms::pad::uint_to_be_pad_into(s, k, sig_storage)
+    crate::algorithms::pad::uint_to_zeroizing_be_pad_into(s, k, sig_storage)
 }
 
 fn emsa_pss_verify_pre<'a>(

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -155,6 +155,7 @@ impl<D, T, M> GenericSigningKey<D, T, M>
 where
     D: Digest,
     T: UnsignedModularInt + Zeroize,
+    T::Bytes: Zeroize,
     M: ModulusParams<Modulus = T>,
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
 {

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -145,6 +145,7 @@ impl<D, T, M> GenericSigningKey<D, T, M>
 where
     D: Digest + FixedOutputReset,
     T: UnsignedModularInt + Zeroize,
+    T::Bytes: Zeroize,
     M: ModulusParams<Modulus = T>,
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
 {


### PR DESCRIPTION
## Summary

`fixed-bigint 0.3.2` now provides `Zeroize` for `BytesHolder`, so the `T::Bytes: Zeroize` bound the zeroizing padding path needs is satisfiable on the heapless backends.

- Bumps `fixed-bigint` from `0.3.0` to `0.3.2` in `Cargo.toml`.
- Swaps `uint_to_be_pad_into` → `uint_to_zeroizing_be_pad_into` in both `pkcs1v15::sign_into` and `pss::sign_into`, closing the soft-leak window where the intermediate `T::Bytes` produced by `s.to_be_bytes()` briefly carried the just-signed value on the stack.
- Adds `T::Bytes: Zeroize` to both `sign_into` primitives and to the wrapping `try_sign_*_into` methods on `pkcs1v15::GenericSigningKey` / `pss::GenericSigningKey`.
- Drops the TODO comments the switch was gated on.

CLAUDE.md "Other follow-up ideas — still open: `Zeroize for BytesHolder` in fixed-bigint" is now landed.

## Test plan
- [x] `cargo check` (default)
- [x] `cargo check --no-default-features --features modmath`
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo test --lib` (97)
- [x] `cargo test --all-features --tests` (17)
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Update RSA signing primitives to use zeroizing padding backed by the newer fixed-bigint release.

Bug Fixes:
- Eliminate the soft-leak window in pkcs1v15 and PSS sign primitives by using a zeroizing serialization path for the signature value.

Enhancements:
- Require Zeroize for T::Bytes in low-level sign_into primitives and GenericSigningKey wrappers to ensure intermediate buffers are cleared.
- Remove obsolete TODO comments related to pending Zeroize support in fixed-bigint.

Build:
- Bump fixed-bigint dependency from 0.3.0 to 0.3.2 in both main and dev dependency sections.