### PR TITLE
Trim over-explaining comments to reduce upstream diff

### DIFF
--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -188,28 +188,16 @@ pub fn pkcs1v15_sign_pad_into<'a>(
 
 /// ⚠️ PKCS#1 v1.5 sign — heapless-compatible, generic over the integer backend.
 ///
-/// Composes the four byte/integer steps of `RSASSA-PKCS1-V1_5-SIGN`:
-///
-/// 1. Build the padded encoding
-///    `EM = 0x00 || 0x01 || PS || 0x00 || prefix || hashed` in
-///    caller-provided `em_storage`.
-/// 2. Convert the EM bytes to integer `T` via
-///    [`UnsignedModularInt::try_from_be_bytes_vartime`].
-/// 3. Compute `s = EM^d mod n` via
-///    [`crate::algorithms::rsa::rsa_private_op_and_check`] — CT in the secret
-///    exponent on the Ct-personality heapless path, with a verify-after-sign
-///    integrity check on every backend.
-/// 4. Serialize `s` to bytes, left-padded with zeros to length `k`, into
-///    caller-provided `sig_storage`.
-///
-/// `k` is the byte length of the modulus `n` and determines both the EM
-/// and signature lengths. Both scratch buffers must be at least `k` bytes.
+/// Pads `hashed` into `EM = 0x00 || 0x01 || PS || 0x00 || prefix || hashed`,
+/// computes `s = EM^d mod n` via
+/// [`rsa_private_op_and_check`](crate::algorithms::rsa::rsa_private_op_and_check)
+/// (verify-after-sign on every backend), and writes `s` left-padded to `k`
+/// bytes. `k` is the modulus byte length; both scratch buffers must be `>= k`.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
-/// This is the raw PKCS#1 v1.5 sign primitive over a precomputed modulus
-/// context. Higher-level callers should hash the input message themselves
-/// and prepend the appropriate digest-algorithm DigestInfo prefix.
+/// The raw PKCS#1 v1.5 sign primitive — the caller hashes the message and
+/// prepends the DigestInfo prefix.
 ///
 // Consumer (the heapless `SigningKey<D>` wrapper) lands in a later PR.
 #[allow(dead_code)]
@@ -231,21 +219,14 @@ where
     M: ModulusParams<Modulus = T>,
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
 {
-    // `k` must equal the ceiling-byte length of the modulus, matching
-    // `PublicKeyParts::size()` (which the public-side verifier uses for
-    // its own length check). Use the actual modulus bit-length, not the
-    // container width — for a shorter modulus stored in a wider integer
-    // (e.g. a 1024-bit RSA key on `U2048`) `bits_precision()` returns
-    // the container width and would reject the only valid `k`. Also
-    // `div_ceil` not floor — for a key whose bit-length isn't a
-    // multiple of 8 (e.g. an imported 2049-bit RSA modulus) the floor
-    // would reject the only `k` value that would actually round-trip.
+    // `k` = modulus byte length (matches `PublicKeyParts::size()`). Use the
+    // actual bit-length, not the container width (`bits_precision()` would
+    // over-count a short modulus in a wide integer), and `div_ceil` so a
+    // non-multiple-of-8 modulus still round-trips.
     if k != (n_params.modulus().as_ref().bits() as usize).div_ceil(8) {
         return Err(Error::InvalidArguments);
     }
-    // Fail fast on a too-small `sig_storage` rather than letting
-    // `uint_to_be_pad_into` surface `OutputBufferTooSmall` after the
-    // exponentiation work is already done.
+    // Fail fast before the exponentiation instead of after.
     if sig_storage.len() < k {
         return Err(Error::OutputBufferTooSmall);
     }

--- a/src/algorithms/pss.rs
+++ b/src/algorithms/pss.rs
@@ -204,27 +204,17 @@ where
 
 /// ⚠️ RSASSA-PSS sign — heapless-compatible, generic over the integer backend.
 ///
-/// Composes the four byte/integer steps of RSASSA-PSS-SIGN:
-///
-/// 1. [`emsa_pss_encode_into`] — build the EM encoding for `(m_hash, salt)`
-///    into `em_storage`. `em_bits = key_bits - 1` per RFC 8017 § 8.1.1 is
-///    derived internally from the actual modulus bit-length.
-/// 2. [`UnsignedModularInt::try_from_be_bytes_vartime`] — bytes → integer.
-/// 3. [`crate::algorithms::rsa::rsa_private_op_and_check`] — CT in the
-///    secret exponent on the Ct-personality heapless path, with a
-///    verify-after-sign integrity check on every backend.
-/// 4. `uint_to_be_pad_into` — integer → bytes, left-padded to `k`.
-///
-/// `k` is the byte length of the modulus `n` (matches
-/// `PublicKeyParts::size()`). `sig_storage.len() >= k` and
-/// `em_storage.len() >= em_len` are both checked up front; either
-/// produces a fast-fail error before any hashing or exponentiation runs.
+/// EMSA-PSS-encodes `(m_hash, salt)` (`em_bits = key_bits - 1`, RFC 8017
+/// § 8.1.1), computes `s = EM^d mod n` via
+/// [`rsa_private_op_and_check`](crate::algorithms::rsa::rsa_private_op_and_check)
+/// (verify-after-sign on every backend), and writes `s` left-padded to `k`
+/// bytes. `k` is the modulus byte length; `sig_storage`/`em_storage` are
+/// length-checked up front.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
-/// Caller is responsible for hashing the message and generating the random
-/// `salt`. This is the raw PSS sign primitive — wrap it in a higher-level
-/// `SigningKey<D>` for real use.
+/// The raw PSS sign primitive — the caller hashes the message and generates
+/// the random `salt`.
 ///
 // Consumer (the heapless `pss::SigningKey<D>` wrapper) lands in a later PR.
 #[allow(dead_code)]
@@ -248,17 +238,9 @@ where
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
     D: Digest + FixedOutputReset,
 {
-    // `k` must equal the ceiling-byte length of the modulus, matching
-    // `PublicKeyParts::size()` (which the public-side verifier uses for
-    // its own length check). Use the actual modulus bit-length, not the
-    // container width — for a shorter modulus stored in a wider integer
-    // (e.g. a 1024-bit RSA key on `U2048`) `bits_precision()` returns
-    // the container width and would reject the only valid `k`. Also
-    // `div_ceil` not floor — for a key whose bit-length isn't a
-    // multiple of 8 (e.g. an imported 2049-bit RSA modulus) the floor
-    // would reject the only `k` value that would actually round-trip.
-    // `em_bits = key_bits - 1` per RFC 8017 § 8.1.1 also needs the
-    // actual modulus bit-length.
+    // `k` = modulus byte length (matches `PublicKeyParts::size()`). Use the
+    // actual bit-length, not the container width, and `div_ceil` so a
+    // non-multiple-of-8 modulus still round-trips; `em_bits` needs it too.
     let key_bits = n_params.modulus().as_ref().bits() as usize;
     if k != key_bits.div_ceil(8) {
         return Err(Error::InvalidArguments);

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -86,11 +86,9 @@ where
         c.try_resize(bits).ok_or(Error::Internal)?
     };
 
-    // Bind once — `PrivateKeyParts::primes` default returns `&[]`,
-    // so a key that overrides the CRT accessors but not `primes` could
-    // otherwise reach the CRT branch and panic on `[0]`/`[1]`. The
-    // `primes.len() >= 2` guard below makes that impossible regardless
-    // of how the trait is implemented.
+    // `primes()` defaults to `&[]`; the `primes.len() >= 2` guard below
+    // keeps a key with CRT accessors but no primes off the `[0]`/`[1]`
+    // panic path.
     let primes = PrivateKeyParts::primes(priv_key);
     let is_multiprime = primes.len() > 2;
 
@@ -270,10 +268,9 @@ fn unblind(m: &BoxedUint, unblinder: &BoxedUint, n_params: &BoxedMontyParams) ->
 
 /// ⚠️ Performs the raw RSA private-key operation `c^d mod n`.
 ///
-/// This is the bare primitive that both signing and unblinded decryption reduce
-/// to. The operation is constant-time in both base and secret exponent when
-/// `M::MontgomeryForm: Pow<M>` resolves to a Ct-personality implementation
-/// (e.g. `modmath::Field<T, Ct>` via the heapless `modmath_support` adapter).
+/// The bare primitive both signing and unblinded decryption reduce to.
+/// Constant-time in base and exponent when `M::MontgomeryForm: Pow<M>`
+/// resolves to a Ct-personality impl.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
@@ -291,17 +288,10 @@ where
     pow_mod_params(c, d, n_params)
 }
 
-/// ⚠️ Performs `rsa_private_op` and verifies the result by re-encrypting
-/// and comparing against the input. This is the integrity check that
-/// PKCS#1 v1.5 / PSS signing reduce to (mirroring the upstream
-/// `rsa_decrypt_and_check` for the raw-exponent path).
-///
-/// Returns the recovered message `m = c^d mod n` only if `m^e mod n == c`,
-/// otherwise [`Error::Internal`]. Defends against transient compute errors
-/// that would otherwise emit a malformed signature (notably the class of
-/// fault attacks that try to leak `p`/`q` from a corrupted CRT step;
-/// today's heapless raw-exponent path doesn't take that branch but the
-/// check shape stays consistent with the upstream invariant).
+/// ⚠️ Performs `rsa_private_op`, then verifies by re-encrypting: returns
+/// `m = c^d mod n` only if `m^e mod n == c`, else [`Error::Internal`]. The
+/// signing-side analogue of `rsa_decrypt_and_check`; guards against
+/// transient compute/fault errors emitting a malformed signature.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
@@ -319,10 +309,9 @@ where
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
 {
     let m = rsa_private_op(c, d, n_params);
-    // `m < n` by construction (output of `rsa_private_op` is in `[0, n)` after
-    // Montgomery retrieve), so we route through `from_reduced` to skip the
-    // variable-time reduction `from_value` would perform on BoxedUint —
-    // `from_value -> rem_vartime` would otherwise leak `m` via timing.
+    // `m < n` by construction, so use `from_reduced` to skip the
+    // variable-time reduction `from_value` (→ `rem_vartime`) would do on
+    // BoxedUint and leak `m` via timing.
     let m_sized = m.clone().resize_unchecked(n_params.bits_precision());
     let m_mont = M::MontgomeryForm::from_reduced(m_sized, n_params);
     let check = m_mont.pow_bounded_exp(e, e.bits()).retrieve();

--- a/src/key.rs
+++ b/src/key.rs
@@ -98,17 +98,9 @@ where
 
 /// Generic RSA private key — heapless-compatible value type.
 ///
-/// Holds the public components plus the secret exponent `d`. Mirrors
-/// [`GenericRsaPublicKey`] in shape; satisfies both [`PublicKeyParts<T>`]
-/// (via delegation to the inner pubkey) and [`PrivateKeyParts<T>`]
-/// — the Montgomery parameter type `M` comes through `PublicKeyParts`'s
-/// `MontyParams` associated type.
-///
-/// Deliberately minimal: no `primes`, no `precomputed` CRT values, no
-/// keygen. This is the (n, e, d) private form suitable for the raw
-/// signing path. CRT support arrives later behind a separate
-/// extension trait when the dependency stack provides CT modular
-/// inverse — see the roadmap in `CLAUDE.md`.
+/// Holds the public components plus the secret exponent `d`. The raw
+/// `(n, e, d)` form: `primes`, `precomputed` CRT values, and keygen are
+/// alloc-gated and absent on the heapless path.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub struct GenericRsaPrivateKey<T, M>
 where
@@ -119,24 +111,19 @@ where
     pubkey_components: GenericRsaPublicKey<T, M>,
     /// Private exponent.
     d: T,
-    /// Prime factors of N (≥ 2 elements when populated). Empty `Vec`
-    /// when constructed without primes — the heapless raw-`(n, e, d)`
-    /// path. Alloc-gated because `Vec` itself requires alloc; heapless
-    /// builds don't store primes.
+    /// Prime factors of N (≥ 2 elements when populated), empty when
+    /// constructed without primes. Alloc-gated (`Vec` needs alloc).
     #[cfg(feature = "alloc")]
     pub(crate) primes: alloc::vec::Vec<T>,
-    /// Precomputed CRT values, when available. Populated by
-    /// alloc-side constructors that do the CRT precompute; left
-    /// `None` by heapless / raw constructors.
+    /// Precomputed CRT values, when available; `None` on the raw path.
     #[cfg(feature = "private-key")]
     pub(crate) precomputed: Option<PrecomputedValues<T, M>>,
 }
 
-// Manual Clone impl — `#[derive(Clone)]` doesn't synthesize the
-// `M::MontgomeryForm: Clone` is only needed when the `precomputed`
-// field is present (private-key feature on). Heapless backends whose
-// `MontgomeryForm` doesn't impl `Clone` can still use the wip-private-key
-// build path — keep the extra bound off that variant.
+// Manual `Clone`: the `M::MontgomeryForm: Clone` bound is only needed
+// when the `precomputed` field exists (private-key on). Keep it off the
+// wip-private-key variant so backends without a `Clone` MontgomeryForm
+// still build.
 #[cfg(feature = "private-key")]
 impl<T, M> Clone for GenericRsaPrivateKey<T, M>
 where
@@ -170,9 +157,7 @@ where
     }
 }
 
-// Manual `Debug` impl — never print `d`. Mirrors the redaction in the
-// existing alloc-side `RsaPrivateKey::fmt` so `{:?}` on a key value
-// can't leak private material into logs.
+// Manual `Debug` — never print `d`, so `{:?}` can't leak private material.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> fmt::Debug for GenericRsaPrivateKey<T, M>
 where
@@ -189,13 +174,10 @@ where
 }
 
 // Raw `(public_key, d)` constructor — gated on
-// [`RawPrivateKeyConstructible`] so it isn't callable on the
-// `RsaPrivateKey = GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`
-// alias. `BoxedUint` deliberately doesn't impl the marker; alloc-side
-// callers must go through the validated `RsaPrivateKey::from_components`
-// / `from_p_q` / `from_primes` paths so empty `primes` can't leak into
-// CRT-aware APIs (`precompute`, `crt_coefficient`, PKCS#1 encoding) as
-// `primes[0]` index panics. Heapless backends opt in via the marker.
+// [`RawPrivateKeyConstructible`], which `BoxedUint` doesn't impl, so it's
+// unreachable on the `RsaPrivateKey` alias. Alloc callers must use the
+// validated `from_components` / `from_p_q` / `from_primes` paths so empty
+// `primes` can't leak into CRT-aware APIs as a `primes[0]` panic.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> GenericRsaPrivateKey<T, M>
 where
@@ -203,17 +185,9 @@ where
     M: ModulusParams<Modulus = T>,
 {
     /// Construct from an already-built public key and the private
-    /// exponent `d`. Caller is responsible for the cryptographic
-    /// relationship between `n`, `e`, and `d` (typically
-    /// `e * d ≡ 1 mod λ(n)`); no validation is performed here. No CRT
-    /// precompute is attached — use the alloc-side
-    /// [`RsaPrivateKey::from_components`] to take raw `n`/`e`/`d` plus
-    /// primes and run validation + CRT precompute.
-    ///
-    /// Gated on [`RawPrivateKeyConstructible`], which `BoxedUint`
-    /// deliberately doesn't impl, so this method is unreachable on
-    /// the `RsaPrivateKey` alias. See that alias's docstring for a
-    /// `compile_fail` doctest that locks the behavior in.
+    /// exponent `d`. No validation and no CRT precompute — the caller
+    /// owns the `e·d ≡ 1 mod λ(n)` relationship. For validated keys use
+    /// the alloc-side [`RsaPrivateKey::from_components`].
     pub fn from_public_and_d(pubkey_components: GenericRsaPublicKey<T, M>, d: T) -> Self {
         Self {
             pubkey_components,
@@ -269,9 +243,7 @@ where
         &self.d
     }
 
-    // Gate matches the `primes` field (which is `cfg(feature = "alloc")`).
-    // `private-key` implies `alloc` today, but be explicit so this stays
-    // consistent if the implication ever loosens.
+    // Gate matches the `primes` field (`cfg(alloc)`).
     #[cfg(all(feature = "private-key", feature = "alloc"))]
     fn primes(&self) -> &[T] {
         &self.primes
@@ -303,10 +275,8 @@ where
     }
 }
 
-// Canonical `Zeroize` shape: impl on the type, `Drop` delegates so
-// the wipe lives in one place, `ZeroizeOnDrop` is the load-bearing
-// marker callers can rely on. Mirrors the `ModMathForm` pattern from
-// PR #17. The pubkey is public material; only `d` needs wiping.
+// `Zeroize` on the type; `Drop` delegates so the wipe lives in one place.
+// Only `d` (and CRT precompute) is secret — the pubkey is public.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> Zeroize for GenericRsaPrivateKey<T, M>
 where
@@ -342,15 +312,10 @@ where
 }
 
 /// Boxed RSA private key alias used by the `alloc` code path. Equivalent
-/// to `GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`. Mirrors the
-/// [`RsaPublicKey`] alias and lets the public-API surface stay
-/// unchanged while the storage shape is shared with the heapless
-/// (`wip-private-key`) path.
+/// to `GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>`.
 ///
-/// The raw `(public_key, d)` constructor on
-/// [`GenericRsaPrivateKey::from_public_and_d`] is gated on
-/// [`RawPrivateKeyConstructible`], which `BoxedUint` deliberately
-/// doesn't impl, so it's unreachable through this alias:
+/// `from_public_and_d` is unreachable through this alias — `BoxedUint`
+/// doesn't impl [`RawPrivateKeyConstructible`]:
 ///
 /// ```compile_fail
 /// use rsa_heapless::RsaPrivateKey;
@@ -361,9 +326,8 @@ where
 #[cfg(feature = "private-key")]
 pub type RsaPrivateKey = GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>;
 
-// `Debug`, `Drop`, `ZeroizeOnDrop`, and `PublicKeyParts<BoxedUint>` are
-// provided by the generic `GenericRsaPrivateKey<T, M>` impls and apply
-// automatically through the alias.
+// `Debug`, `Drop`, `ZeroizeOnDrop`, `PublicKeyParts` come from the generic
+// impls above via the alias.
 
 #[cfg(feature = "private-key")]
 impl Eq for GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {}
@@ -414,9 +378,8 @@ where
     pub(crate) q_params: M,
 }
 
-// Manual Clone impl — `#[derive(Clone)]` doesn't synthesize the
-// `M::MontgomeryForm: Clone` bound, only `T: Clone` and `M: Clone`.
-// We need the associated-type bound explicit.
+// Manual `Clone` — `#[derive]` wouldn't add the `M::MontgomeryForm: Clone`
+// bound, only `T: Clone` / `M: Clone`.
 #[cfg(feature = "private-key")]
 impl<T, M> Clone for PrecomputedValues<T, M>
 where
@@ -452,21 +415,18 @@ where
     fn zeroize(&mut self) {
         self.dp.zeroize();
         self.dq.zeroize();
-        // KNOWN GAP: `qinv` (M::MontgomeryForm), `p_params` / `q_params`
-        // (M) are not wiped because the trait doesn't require them to
-        // impl `Zeroize`, and upstream `BoxedMontyForm` /
-        // `BoxedMontyParams` don't yet. Re-enable once the dep stack
-        // does:
+        // KNOWN GAP: `qinv`/`p_params`/`q_params` aren't wiped — the trait
+        // doesn't require `Zeroize` and upstream `BoxedMontyForm` /
+        // `BoxedMontyParams` don't impl it yet. Re-enable when they do:
         // self.qinv.zeroize();
         // self.p_params.zeroize();
         // self.q_params.zeroize();
     }
 }
 
-// `Drop` impl bounds must match the struct's exactly (Rust drop-check
-// rule). `T: UnsignedModularInt` already implies `T: Zeroize` via the
-// `FixedWidthUnsignedInt` supertrait, so the body's `self.zeroize()`
-// call resolves without an explicit `Zeroize` bound here.
+// Drop-check requires the bounds match the struct exactly. `T:
+// UnsignedModularInt` already implies `Zeroize` (via `FixedWidthUnsignedInt`),
+// so `self.zeroize()` resolves here.
 #[cfg(feature = "private-key")]
 impl<T, M> Drop for PrecomputedValues<T, M>
 where
@@ -539,9 +499,6 @@ where
     M: ModulusParams<Modulus = T>,
 {
     /// Encrypt the given message.
-    ///
-    /// Bound `M: CtModulusParams` — `NctPublicKey`-derived keys can't
-    /// reach this entry point.
     #[cfg(feature = "alloc")]
     pub fn encrypt<R: CryptoRng + ?Sized, P: PaddingScheme>(
         &self,

--- a/src/oaep/encrypting_key.rs
+++ b/src/oaep/encrypting_key.rs
@@ -84,10 +84,6 @@ where
     }
 }
 
-// `M: CtModulusParams` — encrypt on an NCT-personality key would
-// silently downgrade the plaintext (secret!) to vartime work; refuse
-// to compile in that case. Signature verification stays personality-
-// agnostic.
 impl<D, MGD, T, M> RandomizedEncryptor for GenericEncryptingKey<D, MGD, T, M>
 where
     D: Digest,

--- a/src/pkcs1v15/encrypting_key.rs
+++ b/src/pkcs1v15/encrypting_key.rs
@@ -50,10 +50,6 @@ where
     }
 }
 
-// `M: CtModulusParams` — encrypt on an NCT-personality key would
-// silently downgrade the plaintext (secret!) to vartime work; refuse
-// to compile in that case. Signature verification stays personality-
-// agnostic.
 impl<T, M> RandomizedEncryptor for GenericEncryptingKey<T, M>
 where
     T: UnsignedModularInt,

--- a/src/pkcs1v15/signing_key.rs
+++ b/src/pkcs1v15/signing_key.rs
@@ -1,15 +1,3 @@
-//! Boxed RSASSA-PKCS1-v1_5 signing key — alloc-side type alias and
-//! specializations over [`super::GenericSigningKey`]. Mirrors the
-//! pattern on the verify side (`verifying_key.rs`).
-//!
-//! The struct, generic constructors (`new`, `new_unprefixed`), `Clone`,
-//! `Debug`, `AsRef<GenericRsaPrivateKey<T, M>>`, `Zeroize`, and the
-//! `try_sign_into` family all live on [`super::GenericSigningKey`].
-//! This file holds only what's tied to the boxed substitution:
-//! keygen-bearing constructors, the `signature::*Signer` trait
-//! family (which delegates to the alloc-side `sign(...)`), encoding,
-//! serde, and the legacy `Keypair` wiring.
-
 use super::{sign, GenericSigningKey, GenericVerifyingKey, Signature, VerifyingKey};
 use crate::{dummy_rng::DummyRng, Result, RsaPrivateKey};
 use const_oid::AssociatedOid;
@@ -37,9 +25,7 @@ use {
     serdect::serde::{de, ser, Deserialize, Serialize},
 };
 
-/// Signing key for `RSASSA-PKCS1-v1_5` signatures as described in
-/// [RFC8017 § 8.2]. Boxed alias over [`GenericSigningKey`] — equivalent
-/// to `GenericSigningKey<D, BoxedUint, BoxedMontyParams>`.
+/// Signing key for `RSASSA-PKCS1-v1_5` signatures as described in [RFC8017 § 8.2].
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 pub type SigningKey<D> = GenericSigningKey<D, BoxedUint, BoxedMontyParams>;
@@ -48,8 +34,7 @@ impl<D> GenericSigningKey<D, BoxedUint, BoxedMontyParams>
 where
     D: Digest + AssociatedOid,
 {
-    /// Generate a fresh RSA key pair of the given bit size, then wrap
-    /// it in a signing key with the DigestInfo prefix for `D`.
+    /// Generate a new signing key with a prefix for the digest `D`.
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         Ok(Self::new(RsaPrivateKey::new(rng, bit_size)?))
     }
@@ -59,8 +44,7 @@ impl<D> GenericSigningKey<D, BoxedUint, BoxedMontyParams>
 where
     D: Digest,
 {
-    /// Generate a fresh RSA key pair of the given bit size with an empty
-    /// prefix (raw signatures, no DigestInfo wrapper).
+    /// Generate a new signing key with an empty prefix.
     pub fn random_unprefixed<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         Ok(Self::new_unprefixed(RsaPrivateKey::new(rng, bit_size)?))
     }

--- a/src/pss/blinded_signing_key.rs
+++ b/src/pss/blinded_signing_key.rs
@@ -26,13 +26,7 @@ use {
 
 /// Signing key for producing "blinded" RSASSA-PSS signatures as described in
 /// [draft-irtf-cfrg-rsa-blind-signatures](https://datatracker.ietf.org/doc/draft-irtf-cfrg-rsa-blind-signatures/).
-///
-/// Thin newtype over [`SigningKey`] — same storage, same encoding /
-/// serde / keypair / `AsRef<RsaPrivateKey>` behavior. The only
-/// behavioral difference: the `signature::*Signer` impls pass
-/// `blinded = true` to the underlying `sign_digest`, applying
-/// blinding to the private-key operation.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct BlindedSigningKey<D>(SigningKey<D>)
 where
     D: Digest;
@@ -42,7 +36,8 @@ where
     D: Digest,
 {
     /// Create a new RSASSA-PSS signing key which produces "blinded"
-    /// signatures. Digest output size is used as a salt length.
+    /// signatures.
+    /// Digest output size is used as a salt length.
     pub fn new(key: RsaPrivateKey) -> Self {
         Self(SigningKey::new(key))
     }
@@ -54,7 +49,8 @@ where
     }
 
     /// Create a new random RSASSA-PSS signing key which produces "blinded"
-    /// signatures. Digest output size is used as a salt length.
+    /// signatures.
+    /// Digest output size is used as a salt length.
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         SigningKey::random(rng, bit_size).map(Self)
     }
@@ -76,10 +72,7 @@ where
 }
 
 //
-// `*Signer` trait impls — the only carriers of the blinded behavior.
-// Delegate through `SigningKey<D>`'s public accessors (`AsRef<RsaPrivateKey>`
-// and `salt_len()`) to call `sign_digest` with `blinded = true`, keeping
-// the wrapper independent of `SigningKey`'s field layout.
+// `*Signer` trait impls
 //
 
 impl<D> RandomizedSigner<Signature> for BlindedSigningKey<D>
@@ -161,7 +154,7 @@ where
 }
 
 //
-// Other trait impls — all delegate to the inner `SigningKey<D>`.
+// Other trait impls
 //
 
 impl<D> AsRef<RsaPrivateKey> for BlindedSigningKey<D>

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -1,16 +1,3 @@
-//! Boxed RSASSA-PSS signing key — alloc-side type alias and
-//! specializations over [`super::GenericSigningKey`]. Mirrors the
-//! pattern on the verify side (`verifying_key.rs`).
-//!
-//! The struct, generic constructors (`new`, `new_with_salt_len`),
-//! `Clone`, `Debug`, `AsRef<GenericRsaPrivateKey<T, M>>`, `Zeroize`,
-//! and the `try_sign_*_into` family all live on
-//! [`super::GenericSigningKey`]. This file holds only what's tied to
-//! the boxed substitution: keygen-bearing constructors, the
-//! `signature::*Signer` trait family (delegating to the alloc-side
-//! `sign_digest(...)`), encoding, serde, and the legacy `Keypair`
-//! wiring.
-
 use super::{sign_digest, GenericSigningKey, Signature, VerifyingKey};
 use crate::{Result, RsaPrivateKey};
 use crypto_bigint::{modular::BoxedMontyParams, BoxedUint};
@@ -47,8 +34,7 @@ use {
 };
 
 /// Signing key for producing RSASSA-PSS signatures as described in
-/// [RFC8017 § 8.1]. Boxed alias over [`GenericSigningKey`] — equivalent
-/// to `GenericSigningKey<D, BoxedUint, BoxedMontyParams>`.
+/// [RFC8017 § 8.1].
 ///
 /// [RFC8017 § 8.1]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.1
 pub type SigningKey<D> = GenericSigningKey<D, BoxedUint, BoxedMontyParams>;
@@ -57,14 +43,13 @@ impl<D> GenericSigningKey<D, BoxedUint, BoxedMontyParams>
 where
     D: Digest,
 {
-    /// Generate a fresh RSASSA-PSS signing key. Digest output size is
-    /// used as a salt length.
+    /// Generate a new random RSASSA-PSS signing key.
+    /// Digest output size is used as a salt length.
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         Self::random_with_salt_len(rng, bit_size, <D as Digest>::output_size())
     }
 
-    /// Generate a fresh RSASSA-PSS signing key with a salt of the given
-    /// length.
+    /// Generate a new random RSASSA-PSS signing key with a salt of the given length.
     pub fn random_with_salt_len<R: CryptoRng + ?Sized>(
         rng: &mut R,
         bit_size: usize,

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -5,28 +5,20 @@ use alloc::boxed::Box;
 
 use crate::traits::{modular::ModulusParams, NonZero, UnsignedModularInt};
 
-/// Marker trait gating the raw `(public_key, d)` constructor on
-/// [`crate::key::GenericRsaPrivateKey`] (`from_public_and_d`). Backends
-/// that impl this trait opt in to constructing private keys without
-/// `primes` or CRT precompute — suitable for the heapless /
-/// `wip-private-key` path where the caller already holds validated
-/// `(n, e, d)` material from outside (e.g. PEM/PKCS#8 on disk,
-/// HSM-derived).
+/// Marker trait gating the raw `(public_key, d)` constructor
+/// [`crate::key::GenericRsaPrivateKey::from_public_and_d`]. Backends opt
+/// in to building private keys without `primes` or CRT precompute — the
+/// heapless path, where the caller already holds validated `(n, e, d)`.
 ///
-/// **Intentionally NOT impl'd for [`BoxedUint`]** — alloc-side callers
-/// must use `RsaPrivateKey::from_components` / `from_p_q` /
-/// `from_primes`, which validate the key and populate `primes`
-/// (recovering them via NIST SP 800-56B § C.2 when not provided).
-/// Without that, empty `primes` would leak into CRT-aware APIs
-/// (`precompute`, `crt_coefficient`, PKCS#1 encoding) as `primes[0]`
-/// index panics.
+/// **Not impl'd for [`BoxedUint`]**: alloc callers must use the validated
+/// `RsaPrivateKey::from_components` / `from_p_q` / `from_primes` paths, so
+/// empty `primes` can't leak into CRT-aware APIs as a `primes[0]` panic.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub trait RawPrivateKeyConstructible: UnsignedModularInt {}
 
-// Heapless build: every `FixedWidthUnsignedInt + PartialOrd` matches
-// the heapless `UnsignedModularInt` blanket in `traits/modular.rs` and
-// gets the marker for free. `BoxedUint` isn't `Copy`, so it can never
-// satisfy `FixedWidthUnsignedInt` — excluded structurally.
+// Heapless build: `FixedWidthUnsignedInt + PartialOrd` matches the
+// `UnsignedModularInt` blanket and gets the marker for free. `BoxedUint`
+// isn't `Copy`, so it can't satisfy `FixedWidthUnsignedInt`.
 #[cfg(all(
     any(feature = "private-key", feature = "wip-private-key"),
     not(feature = "alloc")
@@ -77,14 +69,10 @@ pub trait PublicKeyParts<T: UnsignedModularInt> {
 /// Components of an RSA private key — generic over the integer /
 /// Montgomery-parameter backend.
 ///
-/// Mirrors [`PublicKeyParts`] in shape: generic over the integer
-/// type `T`, no concrete dependency on `BoxedUint`/`BoxedMontyParams`.
 /// The base surface is `d()`; the CRT accessors (`dp`/`dq`/`qinv`/
-/// `p_params`/`q_params`) are gated on `feature = "private-key"` so
-/// they only exist on the alloc path — heapless callers physically
-/// can't reach them. Default impls return `None` so a generic key
-/// without precomputed CRT values (e.g. [`GenericRsaPrivateKey`])
-/// satisfies the trait with the minimum.
+/// `p_params`/`q_params`) are `private-key`-gated to the alloc path and
+/// default to `None`, so a key without CRT precompute satisfies the trait
+/// with just `d()`.
 #[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub trait PrivateKeyParts<T>: PublicKeyParts<T>
 where

--- a/src/traits/padding.rs
+++ b/src/traits/padding.rs
@@ -26,11 +26,6 @@ pub trait PaddingScheme {
     ) -> Result<Vec<u8>>;
 
     /// Encrypt the given message using the given public key.
-    ///
-    /// Bound `K::MontyParams: CtModulusParams` — `NctPublicKey`-derived
-    /// keys can't reach this entry point, matching the
-    /// [`crate::traits::RandomizedEncryptor`] gate on
-    /// `GenericEncryptingKey`.
     #[cfg(feature = "alloc")]
     fn encrypt<Rng, K, T>(self, rng: &mut Rng, pub_key: &K, msg: &[u8]) -> Result<Vec<u8>>
     where


### PR DESCRIPTION
## What

Cuts verbose agent-authored comments and reverts needlessly reworded doc comments back to upstream wording across the private-key port. The goal is to shrink this fork's diff against upstream RustCrypto/RSA so tracking upstream commits is easier.

## Scope

**Comment/doc only — zero functional changes.** Bounds (`ModulusParams` → `CtModulusParams`), feature gates, and the generic refactors (`GenericRsaPrivateKey`, `SigningKey`/`BlindedSigningKey` aliases, `PrivateKeyParts<T>`) are all untouched.

Two categories:
- **Reverted to upstream wording** — reworded doc comments and re-flowed lines on `SigningKey`/`BlindedSigningKey` (pss + pkcs1v15), removed added `//!` module headers and the `// M: CtModulusParams …` rationale blocks. These are modifications to lines upstream also has, so reverting them directly reduces merge friction.
- **Trimmed net-new-code essays** — condensed the wordy comments on `GenericRsaPrivateKey`/`PrivateKeyParts` (`key.rs`, `traits/keys.rs`) and the `sign_into`/`rsa_private_op*` primitives (`algorithms/{rsa,pss,pkcs1v15}.rs`) down to their load-bearing facts.

**Deliberately kept:** the `KNOWN GAP` zeroize note, the drop-check bound rationale, the `compile_fail` doctest on the `RsaPrivateKey` alias, and all HAZARDOUS API warnings.

## Diff

11 files, **+97 / −251** (~150 net lines of comment churn removed).

## Verification

- `cargo check --features std,serde,hazmat,sha2,encoding` — pass
- `cargo check --no-default-features --features modmath,wip-private-key` — pass
- `cargo test --doc --features std,encoding,sha2` — 9 passed, 1 ignored (incl. the `compile_fail` guard)

## Summary by Sourcery

Trim and simplify comments and docstrings around RSA private key, signing primitives, and padding traits to align more closely with upstream while preserving hazardous API warnings and behavior notes.

Enhancements:
- Condense verbose comments on GenericRsaPrivateKey, PrecomputedValues, and related traits into shorter explanations without changing behavior.
- Simplify documentation for PKCS#1 v1.5 and PSS signing primitives and their key types while keeping key safety and usage guidance intact.
- Remove or shorten internal rationale comments on modular parameter traits, encrypting keys, and padding APIs to reduce divergence from upstream wording.