### PR TITLE
Expose CT modular inverse in Montgomery form (InvertCt)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
 modmath = { version = "0.4.0", optional = true, default-features = false, features = ["zeroize"] }
+modmath-cios = { version = "0.1.0", optional = true, default-features = false }
 fixed-bigint = { version = "0.4.1", optional = true, default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 subtle = { version = "2.6", default-features = false }
 heapless = "0.9"
@@ -94,7 +95,7 @@ alloc = ["dep:crypto-bigint", "crypto-bigint/alloc", "pkcs8/alloc", "spki/alloc"
 
 # Enable private key support, doesn't work with no-alloc
 private-key = ["alloc", "dep:crypto-primes"]
-modmath = ["dep:modmath", "dep:fixed-bigint"]
+modmath = ["dep:modmath", "dep:modmath-cios", "dep:fixed-bigint"]
 
 # In-progress: gate for individual private-key functions that have been
 # generalized to work on the no_alloc / modmath path. Enabling this alone

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -567,12 +567,15 @@ impl<T: ModMathIntCt + HasPersonality<P = Ct>> PowBoundedExp<ModMathParams<T, Ct
 }
 
 // CT modular inverse for RSA-blinding on the modmath backend. Routes
-// to modmath's `Field<T, Ct>::inv_safegcd_ct` (Bernstein-Yang). Returns
-// `None` when the value shares a factor with `n` (astronomically rare
-// for random `r` against a composite modulus) or when the carrier `T`
-// lacks one bit of headroom over the modulus — see the modmath doc on
-// `inv_safegcd_ct` for the precondition detail. Callers should retry
-// with a fresh random on `None`.
+// to modmath's `Field<T, Ct>::inv_safegcd_ct` (Bernstein-Yang).
+//
+// See the `InvertCt` trait doc for the two `None` cases — retryable
+// (value not coprime with `n`, astronomically rare) vs deterministic
+// (carrier `T` lacks the safegcd headroom bit over the modulus).
+// **These are not interchangeable**: for a 2048-bit modulus in
+// exactly `U2048`, every call returns `None` and no amount of
+// retrying helps — pick a wider carrier (e.g. `U2080` at 32-bit
+// limbs). A blinding loop must preflight this.
 impl<T> crate::traits::modular::InvertCt<ModMathParams<T, Ct>> for ModMathForm<T, Ct>
 where
     T: ModMathIntCt

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -594,7 +594,7 @@ where
         let field = self.params.field();
         let residue = field.residue_from_mont(unwrap_value(&self.integer_mont));
         let ct_option = field.inv_safegcd_ct(&residue);
-        Option::from(ct_option).map(|inv_res: modmath::Residue<'_, T, Ct>| Self {
+        ct_option.into_option().map(|inv_res| Self {
             integer_mont: wrap_value(*inv_res.mont_value()),
             params: self.params.clone(),
         })

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -566,6 +566,41 @@ impl<T: ModMathIntCt + HasPersonality<P = Ct>> PowBoundedExp<ModMathParams<T, Ct
     }
 }
 
+// CT modular inverse for RSA-blinding on the modmath backend. Routes
+// to modmath's `Field<T, Ct>::inv_safegcd_ct` (Bernstein-Yang). Returns
+// `None` when the value shares a factor with `n` (astronomically rare
+// for random `r` against a composite modulus) or when the carrier `T`
+// lacks one bit of headroom over the modulus — see the modmath doc on
+// `inv_safegcd_ct` for the precondition detail. Callers should retry
+// with a fresh random on `None`.
+impl<T> crate::traits::modular::InvertCt<ModMathParams<T, Ct>> for ModMathForm<T, Ct>
+where
+    T: ModMathIntCt
+        + HasPersonality<P = Ct>
+        + modmath_cios::CiosRowOps
+        + core::ops::Shl<usize, Output = T>
+        + core::ops::BitOr<Output = T>,
+    <T as modmath_cios::CiosRowOps>::Word: Copy
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeEq
+        + const_num_traits::CtIsZero
+        + const_num_traits::CtParity
+        + const_num_traits::One
+        + const_num_traits::Zero
+        + core::ops::BitAnd<Output = <T as modmath_cios::CiosRowOps>::Word>
+        + core::ops::Shl<usize, Output = <T as modmath_cios::CiosRowOps>::Word>,
+{
+    fn invert_ct(&self) -> Option<Self> {
+        let field = self.params.field();
+        let residue = field.residue_from_mont(unwrap_value(&self.integer_mont));
+        let ct_option = field.inv_safegcd_ct(&residue);
+        Option::from(ct_option).map(|inv_res: modmath::Residue<'_, T, Ct>| Self {
+            integer_mont: wrap_value(*inv_res.mont_value()),
+            params: self.params.clone(),
+        })
+    }
+}
+
 impl<T: ModMathIntCt + HasPersonality<P = Ct>> ModulusParams for ModMathParams<T, Ct> {
     type Modulus = ModMathValue<T>;
     type MontgomeryForm = ModMathForm<T, Ct>;
@@ -828,6 +863,20 @@ mod private_op_tests {
         let recovered =
             crate::algorithms::rsa::rsa_private_op_and_check(&c, &d, &e, &n_params).unwrap();
         assert_eq!(recovered, expected);
+    }
+
+    // Verify the new `InvertCt` primitive on the modmath backend against
+    // a known-answer inverse. n = 35, 3⁻¹ mod 35 = 12 (since 3·12 = 36 ≡ 1).
+    // Exercises the modmath `Field::inv_safegcd_ct` bridge.
+    #[test]
+    fn invert_ct_modmath_known_answer() {
+        use crate::traits::modular::{IntoMontyForm, InvertCt, PowBoundedExp};
+        let n_params = toy_params();
+        let three = wrap_value(SmallUCt::from(3u8));
+        let mont_three = ModMathForm::<SmallUCt, Ct>::from_reduced(three, &n_params);
+        let mont_inv = mont_three.invert_ct().expect("3 is coprime to 35");
+        let recovered = PowBoundedExp::<ModMathParams<SmallUCt, Ct>>::retrieve(&mont_inv);
+        assert_eq!(recovered, wrap_value(SmallUCt::from(12u8)));
     }
 
     #[test]

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -342,11 +342,35 @@ impl Pow<BoxedMontyParams> for BoxedMontyForm {
 /// Constant-time multiplicative inverse in Montgomery form.
 ///
 /// Returns `Some(self⁻¹ mod n)` when the value is coprime to the
-/// modulus (which for RSA `n = p·q` fails only on the astronomically
-/// unlikely case that the caller's random value happens to share a
-/// factor with `n` — retry-on-`None` is the standard defense).
-/// Bridged to backends whose native return is `subtle::CtOption` via
-/// `.into_option()` — same pattern as `NonZero::new`.
+/// modulus and the backend can compute the inverse. Bridged from
+/// `subtle::CtOption` via `.into_option()` — same pattern as
+/// `NonZero::new` — on backends whose native return is `CtOption`.
+///
+/// # Failure modes — non-interchangeable
+///
+/// `None` conflates two distinct cases; **callers must not treat them
+/// as interchangeable "retry with fresh input"**:
+///
+/// 1. **Value not coprime to `n`** — retryable. Astronomically rare
+///    when `self` was constructed from a fresh random against RSA
+///    `n = p·q`, but real. Retry with a fresh random up to a small
+///    constant number of times.
+///
+/// 2. **Backend precondition unmet** — **deterministic**. On the
+///    modmath backend, `Field<T, Ct>::inv_safegcd_ct` requires the
+///    carrier `T` to have one bit of headroom over the modulus (see
+///    modmath's docs on the `2·modulus ≤ T::MAX` precondition). When
+///    the modulus fills the carrier's full width (e.g. `U2048` for a
+///    2048-bit RSA modulus at 32-bit limbs), every call returns
+///    `None`. Retrying does not help. Pick `T` one bit wider than
+///    the modulus (e.g. `U2080` for a 2048-bit modulus). The
+///    `BoxedUint` backend has no fixed carrier and does not exhibit
+///    this case.
+///
+/// A blinding loop built on this primitive should preflight the
+/// carrier headroom for the modmath backend (compare modulus MSB
+/// against carrier width) and bail with a permanent error before
+/// entering the retry loop.
 ///
 /// Foundation for the sign-path blinding primitive; consumer lands in
 /// a follow-up PR alongside the RNG-taking `rsa_private_op_blinded`.

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -339,6 +339,29 @@ impl Pow<BoxedMontyParams> for BoxedMontyForm {
     }
 }
 
+/// Constant-time multiplicative inverse in Montgomery form.
+///
+/// Returns `Some(self⁻¹ mod n)` when the value is coprime to the
+/// modulus (which for RSA `n = p·q` fails only on the astronomically
+/// unlikely case that the caller's random value happens to share a
+/// factor with `n` — retry-on-`None` is the standard defense).
+/// Bridged to backends whose native return is `subtle::CtOption` via
+/// `.into_option()` — same pattern as `NonZero::new`.
+///
+/// Foundation for the sign-path blinding primitive; consumer lands in
+/// a follow-up PR alongside the RNG-taking `rsa_private_op_blinded`.
+#[allow(dead_code)]
+pub trait InvertCt<M: ModulusParams>: Sized {
+    fn invert_ct(&self) -> Option<Self>;
+}
+
+#[cfg(feature = "alloc")]
+impl InvertCt<BoxedMontyParams> for BoxedMontyForm {
+    fn invert_ct(&self) -> Option<Self> {
+        self.invert().into_option()
+    }
+}
+
 pub trait ModulusParams: Sized {
     type Modulus: UnsignedModularInt;
     type MontgomeryForm: IntoMontyForm<Self> + PowBoundedExp<Self>;


### PR DESCRIPTION
## Summary

New trait `InvertCt<M>` in `src/traits/modular.rs` — constant-time modular inverse on a `M::MontgomeryForm` value. Foundation for RSA private-key blinding on the heapless sign path, now that `modmath 0.4.0` stable exposes Bernstein-Yang via `Field<T, Ct>::inv_safegcd_ct`.

Returns `Option<Self>` per the fork's existing bridge pattern (crypto-bigint / modmath both natively return `subtle::CtOption`; we `.into_option()` at the boundary, same shape as `NonZero::new`).

## Impls

- **BoxedMontyForm** (alloc): forwards to `crypto-bigint`'s `BoxedMontyForm::invert().into_option()`. Same primitive upstream `RustCrypto/RSA`'s `blind()` helper reaches for on its private path.
- **ModMathForm<T, Ct>** (modmath): forwards to `modmath::Field<T, Ct>::inv_safegcd_ct` — Bernstein-Yang safegcd, CT top to bottom. Adds `modmath-cios = "0.1.0"` to the `modmath` feature's dep set (the safegcd trait bounds pull `CiosRowOps` from it).

## Scope

Foundation only — no consumer yet. Trait carries `#[allow(dead_code)]` while the consumer is being staged.

Follow-up PR will:
- Add `MulCt` (Montgomery-form multiplication trait) and a random-mod primitive.
- Add `rsa_private_op_blinded<R, T, M>(rng, c, d, e, n_params)` using all three.
- Extend `rsa_private_op_and_check` to accept `Option<&mut R>`, mirroring upstream's `rsa_decrypt` signature shape.
- Thread the optional RNG through the sign wrapper API.

Kept separate to keep the CT-inverse capability review-scoped.

## Test plan
- [x] New test `invert_ct_modmath_known_answer` — verifies `3⁻¹ ≡ 12 (mod 35)` via the modmath bridge.
- [x] Alloc-side impl exercised through crypto-bigint's existing test coverage.
- [x] `cargo test --lib` (98)
- [x] `cargo test --all-features --tests` (17)
- [x] `cargo test --doc` (6)
- [x] `cargo check --no-default-features --features modmath`
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Introduce a constant-time Montgomery-form modular inverse trait and implementations for both crypto-bigint and modmath backends to support future RSA private-key blinding.

New Features:
- Add generic InvertCt<M> trait for constant-time modular inversion in Montgomery form returning Option<Self>.
- Provide InvertCt implementation for BoxedMontyForm using crypto-bigint’s boxed Montgomery inverse.
- Provide InvertCt implementation for ModMathForm on the modmath backend via Field::inv_safegcd_ct.

Enhancements:
- Extend modmath backend support with Bernstein–Yang safegcd-based inversion, including necessary trait bounds on the carrier type.

Build:
- Add modmath-cios dependency and wire it into the modmath feature for safegcd inversion support.

Tests:
- Add known-answer test for modmath InvertCt implementation verifying a small modular inverse in Montgomery form.