### PR TITLE
Expose CT Montgomery multiplication (MulCt)

### DIFF
--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -612,6 +612,15 @@ impl<T: ModMathIntCt + HasPersonality<P = Ct>> crate::traits::modular::MulCt<Mod
     for ModMathForm<T, Ct>
 {
     fn mul_ct(&self, rhs: &Self) -> Self {
+        // Guard: MulCt's precondition is that both operands share the
+        // same modulus. `debug_assert_eq!` would need `T: Debug` for
+        // the failure message; use `debug_assert!` with a fixed
+        // message to avoid widening the trait bound just for a
+        // debug-only check.
+        debug_assert!(
+            self.params.modulus_odd == rhs.params.modulus_odd,
+            "MulCt operands must share the same modulus"
+        );
         let field = self.params.field();
         let lhs_res = field.residue_from_mont(unwrap_value(&self.integer_mont));
         let rhs_res = field.residue_from_mont(unwrap_value(&rhs.integer_mont));

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -604,6 +604,25 @@ where
     }
 }
 
+// CT Montgomery multiplication. Both operands share this
+// `ModMathParams` (invariant, not type-checked). Routes to modmath's
+// `Field<T, Ct>::mul` — the CIOS-Ct primitive, branchless in both
+// inputs.
+impl<T: ModMathIntCt + HasPersonality<P = Ct>> crate::traits::modular::MulCt<ModMathParams<T, Ct>>
+    for ModMathForm<T, Ct>
+{
+    fn mul_ct(&self, rhs: &Self) -> Self {
+        let field = self.params.field();
+        let lhs_res = field.residue_from_mont(unwrap_value(&self.integer_mont));
+        let rhs_res = field.residue_from_mont(unwrap_value(&rhs.integer_mont));
+        let product = field.mul(&lhs_res, &rhs_res);
+        Self {
+            integer_mont: wrap_value(*product.mont_value()),
+            params: self.params.clone(),
+        }
+    }
+}
+
 impl<T: ModMathIntCt + HasPersonality<P = Ct>> ModulusParams for ModMathParams<T, Ct> {
     type Modulus = ModMathValue<T>;
     type MontgomeryForm = ModMathForm<T, Ct>;
@@ -880,6 +899,22 @@ mod private_op_tests {
         let mont_inv = mont_three.invert_ct().expect("3 is coprime to 35");
         let recovered = PowBoundedExp::<ModMathParams<SmallUCt, Ct>>::retrieve(&mont_inv);
         assert_eq!(recovered, wrap_value(SmallUCt::from(12u8)));
+    }
+
+    // Verify the new `MulCt` primitive on the modmath backend against a
+    // known-answer product. n = 35, 3·12 = 36 ≡ 1 (mod 35). Exercises
+    // the modmath `Field::mul` bridge; also completes the round-trip
+    // with `InvertCt` — inverting 3 and multiplying back gives 1.
+    #[test]
+    fn mul_ct_modmath_inverse_round_trip() {
+        use crate::traits::modular::{IntoMontyForm, InvertCt, MulCt, PowBoundedExp};
+        let n_params = toy_params();
+        let three = wrap_value(SmallUCt::from(3u8));
+        let mont_three = ModMathForm::<SmallUCt, Ct>::from_reduced(three, &n_params);
+        let mont_inv = mont_three.invert_ct().expect("3 is coprime to 35");
+        let product = mont_three.mul_ct(&mont_inv);
+        let recovered = PowBoundedExp::<ModMathParams<SmallUCt, Ct>>::retrieve(&product);
+        assert_eq!(recovered, wrap_value(SmallUCt::from(1u8)));
     }
 
     #[test]

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -386,6 +386,33 @@ impl InvertCt<BoxedMontyParams> for BoxedMontyForm {
     }
 }
 
+/// Constant-time multiplication in Montgomery form.
+///
+/// The Montgomery form's native multiplication — already CT on both
+/// backends we support (`BoxedMontyForm`'s `Mul` via crypto-bigint,
+/// `ModMathForm<T, Ct>`'s `Field::mul` via modmath's CIOS-Ct). Bounded
+/// on the sign-path blinding body, which does two Mont-form multiplies
+/// per signature: `mont(c) * mont(r^e)` (blind) and
+/// `mont(s') * mont(r⁻¹)` (unblind).
+///
+/// Both operands must share the same `ModulusParams` instance
+/// (invariant: same modulus / same Montgomery R). We don't check that
+/// at the type level; the impls take it as an unchecked precondition.
+///
+/// Foundation for the sign-path blinding primitive; consumer lands
+/// alongside `rsa_private_op_blinded` in a follow-up PR.
+#[allow(dead_code)]
+pub trait MulCt<M: ModulusParams>: Sized {
+    fn mul_ct(&self, rhs: &Self) -> Self;
+}
+
+#[cfg(feature = "alloc")]
+impl MulCt<BoxedMontyParams> for BoxedMontyForm {
+    fn mul_ct(&self, rhs: &Self) -> Self {
+        self * rhs
+    }
+}
+
 pub trait ModulusParams: Sized {
     type Modulus: UnsignedModularInt;
     type MontgomeryForm: IntoMontyForm<Self> + PowBoundedExp<Self>;


### PR DESCRIPTION
## Summary

New trait `MulCt<M>` in `src/traits/modular.rs` — constant-time multiplication on `M::MontgomeryForm`. Same foundation-only shape as PR #41's `InvertCt`.

## Impls

- **BoxedMontyForm** (alloc): forwards to crypto-bigint's `impl Mul<&BoxedMontyForm> for BoxedMontyForm`.
- **ModMathForm<T, Ct>** (modmath): routes to `Field<T, Ct>::mul` — the CIOS-Ct primitive, branchless in both inputs.

Both impls assume the operands share the same `ModulusParams` instance (same modulus / same Montgomery R). Unchecked precondition — matches how Montgomery multiplication is used inside a single `Field` context anyway.

## Scope

Foundation only — no consumer yet. Trait carries `#[allow(dead_code)]` while the consumer is staged.

Sets up the third and final capability for the follow-up blinded op wrapper: `InvertCt` (PR #41), `MulCt` (this PR), random-mod primitive (next). The blinded body needs two Mont-form multiplies per signature:
- `mont(c) · mont(r^e)` (blind)
- `mont(s') · mont(r⁻¹)` (unblind)

## Test plan
- [x] New test `mul_ct_modmath_inverse_round_trip` — 3 · 3⁻¹ ≡ 1 mod 35, combines `InvertCt` and `MulCt` in a single round-trip.
- [x] Alloc-side impl exercised through crypto-bigint's existing test coverage.
- [x] `cargo test --lib` (99, was 98)
- [x] `cargo test --all-features --tests` (17)
- [x] `cargo test --doc` (6)
- [x] `cargo check --no-default-features --features modmath`
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Introduce a constant-time Montgomery multiplication trait and implementations to support future RSA blinding primitives.

New Features:
- Add MulCt trait for constant-time Montgomery-form multiplication over generic ModulusParams.
- Implement MulCt for BoxedMontyForm using the existing crypto-bigint multiplication.
- Implement MulCt for ModMathForm on the modmath backend via Field::mul.

Tests:
- Add mul_ct_modmath_inverse_round_trip test validating MulCt with InvertCt on the modmath backend.