### PR TITLE
Add rsa_private_op_blinded primitive

### DIFF
--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -332,6 +332,70 @@ where
     base.pow(exp).retrieve()
 }
 
+/// ⚠️ Raw RSA private op with base-blinding: `m = ((c · r^e)^d · r⁻¹) mod n`.
+///
+/// Mathematically equivalent to [`rsa_private_op`] but multiplies `c`
+/// by a caller-supplied blinding factor `r` before exponentiating,
+/// then unblinds by `r⁻¹`. Blinding hides `c` from side-channel
+/// analysis on the private-key operation.
+///
+/// # Preconditions on `blinding_r`
+///
+/// - `gcd(blinding_r, n) = 1` — required for `r⁻¹ mod n` to exist.
+///   For random `r` against RSA `n = p·q`, non-coprime is
+///   astronomically rare. Retry-on-`Err` at the caller side is the
+///   standard defense. See the doc on
+///   [`crate::traits::modular::InvertCt`] for the two `None` failure
+///   modes (retryable vs deterministic) — this primitive returns
+///   [`Error::Internal`] for both without distinguishing; the caller
+///   is responsible for preflight (carrier-headroom check on modmath)
+///   and retry policy.
+/// - `blinding_r` is the caller-owned blinding factor. This primitive
+///   does not sample or validate its randomness. Follow-up PR wraps
+///   this with an RNG-taking entry point.
+///
+/// # Returns
+///
+/// The unblinded plaintext `m = c^d mod n`, or [`Error::Internal`] if
+/// the inverse could not be computed.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Raw RSA. Must be wrapped in a padding scheme. See
+/// [module-level docs][crate::hazmat].
+// Consumer (the RNG-taking `rsa_private_op_and_check(rng, ...)` extension
+// + heapless sign wrappers) lands in a later PR.
+#[allow(dead_code)]
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub fn rsa_private_op_blinded<T, M>(blinding_r: &T, c: &T, d: &T, e: &T, n_params: &M) -> Result<T>
+where
+    T: UnsignedModularInt,
+    M: ModulusParams<Modulus = T> + crate::traits::modular::CtModulusParams,
+    M::MontgomeryForm: Pow<M>
+        + PowBoundedExp<M>
+        + crate::traits::modular::InvertCt<M>
+        + crate::traits::modular::MulCt<M>,
+{
+    use crate::traits::modular::{InvertCt, MulCt};
+    // r → Montgomery form; invert. `invert_ct` returns `None` for
+    // both retryable (non-coprime) and deterministic (carrier-tight)
+    // cases — caller preflights the deterministic case.
+    let r_mont = reduce_vartime(blinding_r, n_params);
+    let r_inv_mont = r_mont.invert_ct().ok_or(Error::Internal)?;
+    // r^e (in Montgomery form). Public exponent `e`, so
+    // `pow_bounded_exp` (variable-time-in-exponent semantics) is fine.
+    let r_e_mont = r_mont.pow_bounded_exp(e, e.bits());
+    // c · r^e (Montgomery mul). Blinded ciphertext masks `c` from
+    // subsequent timing analysis on the private op.
+    let c_mont = reduce_vartime(c, n_params);
+    let blinded_mont = c_mont.mul_ct(&r_e_mont);
+    // Private op on the blinded value — CT ladder in `d`.
+    let s_prime_mont = blinded_mont.pow(d);
+    // Unblind: multiply by `r⁻¹` in Montgomery form, retrieve.
+    let s_mont = s_prime_mont.mul_ct(&r_inv_mont);
+    Ok(<M::MontgomeryForm as PowBoundedExp<M>>::retrieve(&s_mont))
+}
+
 /// Computes `base.pow_mod(exp, n)` with a bounded exponent and precomputed `n_params`.
 ///
 /// The exponent bit length `exp_bits` may be leaked in the time pattern.

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -22,7 +22,7 @@ use crate::traits::keys::{PrivateKeyParts, PublicKeyParts};
 use crate::{
     errors::{Error, Result},
     traits::{
-        modular::{IntoMontyForm, ModulusParams, Pow, PowBoundedExp},
+        modular::{IntoMontyForm, InvertCt, ModulusParams, MulCt, Pow, PowBoundedExp},
         UnsignedModularInt,
     },
 };
@@ -371,12 +371,8 @@ pub fn rsa_private_op_blinded<T, M>(blinding_r: &T, c: &T, d: &T, e: &T, n_param
 where
     T: UnsignedModularInt,
     M: ModulusParams<Modulus = T> + crate::traits::modular::CtModulusParams,
-    M::MontgomeryForm: Pow<M>
-        + PowBoundedExp<M>
-        + crate::traits::modular::InvertCt<M>
-        + crate::traits::modular::MulCt<M>,
+    M::MontgomeryForm: Pow<M> + PowBoundedExp<M> + InvertCt<M> + MulCt<M>,
 {
-    use crate::traits::modular::{InvertCt, MulCt};
     // r → Montgomery form; invert. `invert_ct` returns `None` for
     // both retryable (non-coprime) and deterministic (carrier-tight)
     // cases — caller preflights the deterministic case.

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -339,24 +339,33 @@ where
 /// then unblinds by `r⁻¹`. Blinding hides `c` from side-channel
 /// analysis on the private-key operation.
 ///
-/// # Preconditions on `blinding_r`
+/// # Preconditions
 ///
+/// - **`blinding_r < n`** — the blinding factor must already be
+///   reduced modulo `n`. The primitive uses `from_reduced` to convert
+///   to Montgomery form and would leak `r`'s value on the
+///   `BoxedMontyForm` backend via `rem_vartime` if we accepted
+///   unreduced input. Callers should sample `r` from `[1, n)`
+///   directly (via the random-mod primitive landing in the follow-up
+///   PR).
+/// - **`c < n`** — same reason applied to the (secret) message. The
+///   sign path's padded EM always satisfies this (leading 0x00 byte
+///   → `EM < 2^{8(k-1)} < n`).
 /// - `gcd(blinding_r, n) = 1` — required for `r⁻¹ mod n` to exist.
 ///   For random `r` against RSA `n = p·q`, non-coprime is
 ///   astronomically rare. Retry-on-`Err` at the caller side is the
-///   standard defense. See the doc on
-///   [`crate::traits::modular::InvertCt`] for the two `None` failure
-///   modes (retryable vs deterministic) — this primitive returns
-///   [`Error::Internal`] for both without distinguishing; the caller
-///   is responsible for preflight (carrier-headroom check on modmath)
-///   and retry policy.
+///   standard defense. See the doc on `crate::traits::modular::InvertCt`
+///   for the two `None` failure modes (retryable vs deterministic) —
+///   this primitive returns `Error::Internal` for both without
+///   distinguishing; the caller is responsible for the preflight
+///   (carrier-headroom check on modmath) and retry policy.
 /// - `blinding_r` is the caller-owned blinding factor. This primitive
 ///   does not sample or validate its randomness. Follow-up PR wraps
 ///   this with an RNG-taking entry point.
 ///
 /// # Returns
 ///
-/// The unblinded plaintext `m = c^d mod n`, or [`Error::Internal`] if
+/// The unblinded plaintext `m = c^d mod n`, or `Error::Internal` if
 /// the inverse could not be computed.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
@@ -373,17 +382,28 @@ where
     M: ModulusParams<Modulus = T> + crate::traits::modular::CtModulusParams,
     M::MontgomeryForm: Pow<M> + PowBoundedExp<M> + InvertCt<M> + MulCt<M>,
 {
-    // r → Montgomery form; invert. `invert_ct` returns `None` for
-    // both retryable (non-coprime) and deterministic (carrier-tight)
-    // cases — caller preflights the deterministic case.
-    let r_mont = reduce_vartime(blinding_r, n_params);
+    // `blinding_r < n` and `c < n` are caller preconditions — use
+    // `from_reduced` on both to skip the variable-time `rem_vartime`
+    // that `from_value` (via `reduce_vartime`) would do on the
+    // `BoxedMontyForm` backend. Vartime on `r` in particular would
+    // leak the very value that's meant to *defend* against timing
+    // analysis of `c` and `d`.
+    let r_sized = blinding_r
+        .clone()
+        .resize_unchecked(n_params.bits_precision());
+    let r_mont = M::MontgomeryForm::from_reduced(r_sized, n_params);
+    // `invert_ct` returns `None` for both retryable (non-coprime) and
+    // deterministic (carrier-tight) cases — caller preflights the
+    // deterministic case.
     let r_inv_mont = r_mont.invert_ct().ok_or(Error::Internal)?;
     // r^e (in Montgomery form). Public exponent `e`, so
     // `pow_bounded_exp` (variable-time-in-exponent semantics) is fine.
     let r_e_mont = r_mont.pow_bounded_exp(e, e.bits());
+    // c → Montgomery form via `from_reduced` (same reason as `r`).
+    let c_sized = c.clone().resize_unchecked(n_params.bits_precision());
+    let c_mont = M::MontgomeryForm::from_reduced(c_sized, n_params);
     // c · r^e (Montgomery mul). Blinded ciphertext masks `c` from
     // subsequent timing analysis on the private op.
-    let c_mont = reduce_vartime(c, n_params);
     let blinded_mont = c_mont.mul_ct(&r_e_mont);
     // Private op on the blinded value — CT ladder in `d`.
     let s_prime_mont = blinded_mont.pow(d);

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -884,6 +884,39 @@ mod private_op_tests {
         assert_eq!(recovered, expected);
     }
 
+    // Blinded RSA private op must produce the same plaintext as the
+    // unblinded op, regardless of the caller-supplied `r`. Toy modulus
+    // n = 35, e = 5, d = 29, c = 32; expected m = 2. r = 6 (coprime
+    // with 35). The blinded body should recover m = 2 the same way
+    // rsa_private_op does.
+    #[test]
+    fn rsa_private_op_blinded_matches_unblinded_heapless_ct() {
+        let n_params = toy_params();
+        let c = wrap_value(SmallUCt::from(32u8));
+        let d = wrap_value(SmallUCt::from(29u8));
+        let e = wrap_value(SmallUCt::from(5u8));
+        let r = wrap_value(SmallUCt::from(6u8));
+        let expected = wrap_value(SmallUCt::from(2u8));
+        let recovered =
+            crate::algorithms::rsa::rsa_private_op_blinded(&r, &c, &d, &e, &n_params).unwrap();
+        assert_eq!(recovered, expected);
+    }
+
+    // Blinded op must fail if `r` shares a factor with `n` — inverse
+    // doesn't exist, `invert_ct` returns None, primitive returns Err.
+    // Toy: n = 35 = 5·7, r = 5 (shares factor with n). No retry at
+    // the primitive level — caller policy.
+    #[test]
+    fn rsa_private_op_blinded_rejects_non_coprime_r() {
+        let n_params = toy_params();
+        let c = wrap_value(SmallUCt::from(32u8));
+        let d = wrap_value(SmallUCt::from(29u8));
+        let e = wrap_value(SmallUCt::from(5u8));
+        let r_bad = wrap_value(SmallUCt::from(5u8));
+        let result = crate::algorithms::rsa::rsa_private_op_blinded(&r_bad, &c, &d, &e, &n_params);
+        assert!(result.is_err());
+    }
+
     #[test]
     fn rsa_private_op_and_check_round_trip_heapless_ct() {
         let n_params = toy_params();

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -372,8 +372,10 @@ impl Pow<BoxedMontyParams> for BoxedMontyForm {
 /// against carrier width) and bail with a permanent error before
 /// entering the retry loop.
 ///
-/// Consumed by [`crate::algorithms::rsa::rsa_private_op_blinded`] for
-/// the sign-path blinding body.
+/// Consumed by `crate::algorithms::rsa::rsa_private_op_blinded` for
+/// the sign-path blinding body. Plain code span rather than an
+/// intra-doc link because the target is feature-gated and would
+/// break `cargo doc --no-default-features`.
 pub trait InvertCt<M: ModulusParams>: Sized {
     fn invert_ct(&self) -> Option<Self>;
 }
@@ -398,8 +400,10 @@ impl InvertCt<BoxedMontyParams> for BoxedMontyForm {
 /// (invariant: same modulus / same Montgomery R). We don't check that
 /// at the type level; the impls take it as an unchecked precondition.
 ///
-/// Consumed by [`crate::algorithms::rsa::rsa_private_op_blinded`] for
-/// the two Mont-form multiplies per signature.
+/// Consumed by `crate::algorithms::rsa::rsa_private_op_blinded` for
+/// the two Mont-form multiplies per signature. Plain code span
+/// rather than an intra-doc link because the target is feature-gated
+/// and would break `cargo doc --no-default-features`.
 pub trait MulCt<M: ModulusParams>: Sized {
     fn mul_ct(&self, rhs: &Self) -> Self;
 }

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -372,9 +372,8 @@ impl Pow<BoxedMontyParams> for BoxedMontyForm {
 /// against carrier width) and bail with a permanent error before
 /// entering the retry loop.
 ///
-/// Foundation for the sign-path blinding primitive; consumer lands in
-/// a follow-up PR alongside the RNG-taking `rsa_private_op_blinded`.
-#[allow(dead_code)]
+/// Consumed by [`crate::algorithms::rsa::rsa_private_op_blinded`] for
+/// the sign-path blinding body.
 pub trait InvertCt<M: ModulusParams>: Sized {
     fn invert_ct(&self) -> Option<Self>;
 }
@@ -399,9 +398,8 @@ impl InvertCt<BoxedMontyParams> for BoxedMontyForm {
 /// (invariant: same modulus / same Montgomery R). We don't check that
 /// at the type level; the impls take it as an unchecked precondition.
 ///
-/// Foundation for the sign-path blinding primitive; consumer lands
-/// alongside `rsa_private_op_blinded` in a follow-up PR.
-#[allow(dead_code)]
+/// Consumed by [`crate::algorithms::rsa::rsa_private_op_blinded`] for
+/// the two Mont-form multiplies per signature.
 pub trait MulCt<M: ModulusParams>: Sized {
     fn mul_ct(&self, rhs: &Self) -> Self;
 }


### PR DESCRIPTION
## Summary

New raw-RSA primitive `rsa_private_op_blinded<T, M>(blinding_r, c, d, e, n_params)` in `src/algorithms/rsa.rs`. Base-blinded variant of `rsa_private_op`: computes `m = ((c · r^e)^d · r⁻¹) mod n`, mathematically equivalent to `c^d mod n` but hides `c` from side-channel analysis on the private-key operation.

Body is Montgomery-form throughout, consuming the two capabilities staged in PR #41 (`InvertCt`) and PR #42 (`MulCt`), plus the existing `Pow` / `PowBoundedExp`. `#[allow(dead_code)]` on both traits drops off — they now have a real consumer.

## Scope choice

Takes `blinding_r` as a caller-supplied parameter — this PR is primitive-layer only, no RNG plumbing. The follow-up PR will:
- Add a random-mod primitive on the heapless integer type.
- Extend `rsa_private_op_and_check` to accept `Option<&mut R>` (mirroring upstream `rsa_decrypt`'s shape) that internally samples `r` and delegates to `rsa_private_op_blinded`.
- Thread the optional RNG through the sign wrapper API.

Kept split so the crypto math (this PR) and RNG plumbing (next) can be reviewed independently.

## Preconditions on `blinding_r`

Documented explicitly on the primitive:

- `gcd(blinding_r, n) = 1` — non-coprime returns `Err(Internal)`. No distinguishing between the two `None` failure modes on the underlying `InvertCt` (retryable vs deterministic; see PR #41 for the trait doc). Caller owns the preflight (carrier-headroom check on modmath) and retry policy.
- Randomness is caller's responsibility. Primitive doesn't sample or validate.

## Test plan
- [x] `rsa_private_op_blinded_matches_unblinded_heapless_ct` — same toy setup as the existing round-trip, `r = 6`, verifies recovered plaintext matches unblinded.
- [x] `rsa_private_op_blinded_rejects_non_coprime_r` — `r = 5` shares factor with `n = 35`; primitive returns `Err`.
- [x] `cargo test --lib` (101, was 99)
- [x] `cargo test --all-features --tests` (17)
- [x] `cargo test --doc` (6)
- [x] `cargo check --no-default-features --features modmath`
- [x] `cargo check --no-default-features --features modmath,wip-private-key`
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Introduce a base-blinded raw RSA private operation primitive and wire it into the modular traits used for constant‑time inversion and multiplication.

New Features:
- Add rsa_private_op_blinded primitive that performs RSA private operations with caller-supplied base blinding.
- Expose blinding support for raw RSA operations gated behind private-key feature flags.

Enhancements:
- Connect InvertCt and MulCt modular traits to the new RSA blinding primitive as their concrete consumer.

Tests:
- Add heapless constant-time tests verifying blinded RSA matches the unblinded operation and rejects non-coprime blinding factors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a blinded RSA private operation in private-key builds, helping compute RSA private results with optional base blinding.
* **Tests**
  * Added coverage for matching blinded and unblinded results with a valid blinding value.
  * Added a failure case when the blinding value has no valid inverse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->