### PR TITLE
Add RNG-taking blinded sign wrappers on GenericSigningKey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,3 +111,9 @@ opt-level = 2
 
 [profile.bench]
 debug = true
+
+# Temporary — pulling the safegcd carrier-width fix from modmath 0.4.1-alpha.2
+# (`inv_safegcd_ct` no longer needs a headroom bit; single-path blinded sign
+# on `ModMathParams<U2048, Ct>` works). Drop once modmath 0.4.1 is on crates.io.
+[patch.crates-io]
+modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.4.1-alpha.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
-modmath = { version = "0.4.0", optional = true, default-features = false, features = ["zeroize"] }
+modmath = { version = "0.4.1", optional = true, default-features = false, features = ["zeroize"] }
 modmath-cios = { version = "0.1.0", optional = true, default-features = false }
 fixed-bigint = { version = "0.4.1", optional = true, default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 subtle = { version = "2.6", default-features = false }
@@ -111,9 +111,3 @@ opt-level = 2
 
 [profile.bench]
 debug = true
-
-# Temporary — pulling the safegcd carrier-width fix from modmath 0.4.1-alpha.2
-# (`inv_safegcd_ct` no longer needs a headroom bit; single-path blinded sign
-# on `ModMathParams<U2048, Ct>` works). Drop once modmath 0.4.1 is on crates.io.
-[patch.crates-io]
-modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.4.1-alpha.2" }

--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -236,6 +236,60 @@ where
     crate::algorithms::pad::uint_to_zeroizing_be_pad_into(s, k, sig_storage)
 }
 
+/// ⚠️ Raw PKCS#1 v1.5 sign with RNG-driven base-blinding. Same shape
+/// and preconditions as [`sign_into`]; the only difference is that
+/// the private-key operation goes through
+/// [`crate::algorithms::rsa::rsa_private_op_and_check_blinded`],
+/// which hides `EM` (the padded plaintext, secret) from side-channel
+/// analysis on `d`.
+///
+/// Callers who need deterministic PKCS#1 v1.5 signatures (rare —
+/// PKCS#1 v1.5 is not a randomized scheme) can keep using
+/// [`sign_into`]; this variant is the blinded default for the sign
+/// wrapper API.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Raw RSA. Must be wrapped in a padding/signature scheme. See
+/// [module-level docs][crate::hazmat].
+// Consumer (the heapless `SigningKey<D>` wrapper) lands in the same
+// PR that adds this.
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub fn sign_with_rng_into<'sig, R, T, M>(
+    rng: &mut R,
+    n_params: &M,
+    d: &T,
+    e: &T,
+    prefix: &[u8],
+    hashed: &[u8],
+    k: usize,
+    em_storage: &mut [u8],
+    sig_storage: &'sig mut [u8],
+) -> Result<&'sig [u8]>
+where
+    R: rand_core::TryCryptoRng + ?Sized,
+    T: UnsignedModularInt + crate::traits::modular::TryRandomMod,
+    T::Bytes: zeroize::Zeroize,
+    M: ModulusParams<Modulus = T> + crate::traits::modular::CtModulusParams,
+    M::MontgomeryForm: Pow<M>
+        + PowBoundedExp<M>
+        + crate::traits::modular::InvertCt<M>
+        + crate::traits::modular::MulCt<M>,
+{
+    if k != (n_params.modulus().as_ref().bits() as usize).div_ceil(8) {
+        return Err(Error::InvalidArguments);
+    }
+    if sig_storage.len() < k {
+        return Err(Error::OutputBufferTooSmall);
+    }
+    let em_slice = pkcs1v15_sign_pad_into(prefix, hashed, k, em_storage)?;
+    let em = T::try_from_be_bytes_vartime(em_slice)?;
+    let s = crate::algorithms::rsa::rsa_private_op_and_check_blinded(rng, &em, d, e, n_params)?;
+    crate::algorithms::pad::uint_to_zeroizing_be_pad_into(s, k, sig_storage)
+}
+
 #[inline]
 pub(crate) fn pkcs1v15_sign_unpad(prefix: &[u8], hashed: &[u8], em: &[u8], k: usize) -> Result<()> {
     let hash_len = hashed.len();

--- a/src/algorithms/pss.rs
+++ b/src/algorithms/pss.rs
@@ -264,6 +264,69 @@ where
     crate::algorithms::pad::uint_to_zeroizing_be_pad_into(s, k, sig_storage)
 }
 
+/// ⚠️ Raw PSS sign with RNG-driven base-blinding. Same shape and
+/// preconditions as [`sign_into`]; the only difference is that the
+/// private-key operation goes through
+/// [`crate::algorithms::rsa::rsa_private_op_and_check_blinded`],
+/// which hides `EM` (the padded plaintext, secret) from side-channel
+/// analysis on `d`.
+///
+/// PSS's salt sampling stays out-of-scope for this primitive —
+/// callers supply the pre-sampled `salt` bytes as before; the RNG
+/// argument here is used solely for base-blinding. Higher-level
+/// wrappers (`pss::GenericSigningKey::try_sign_with_rng_into`)
+/// coordinate reusing the same RNG for both.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Raw RSA. Must be wrapped in a padding/signature scheme. See
+/// [module-level docs][crate::hazmat].
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
+pub fn sign_with_rng_into<'sig, R, T, M, D>(
+    rng: &mut R,
+    n_params: &M,
+    d: &T,
+    e: &T,
+    m_hash: &[u8],
+    salt: &[u8],
+    k: usize,
+    hash: &mut D,
+    em_storage: &mut [u8],
+    sig_storage: &'sig mut [u8],
+) -> Result<&'sig [u8]>
+where
+    R: rand_core::TryCryptoRng + ?Sized,
+    T: UnsignedModularInt + crate::traits::modular::TryRandomMod,
+    T::Bytes: zeroize::Zeroize,
+    M: ModulusParams<Modulus = T> + crate::traits::modular::CtModulusParams,
+    M::MontgomeryForm: Pow<M>
+        + PowBoundedExp<M>
+        + crate::traits::modular::InvertCt<M>
+        + crate::traits::modular::MulCt<M>,
+    D: Digest + FixedOutputReset,
+{
+    let key_bits = n_params.modulus().as_ref().bits() as usize;
+    if key_bits < 2 {
+        return Err(Error::InvalidArguments);
+    }
+    if k != key_bits.div_ceil(8) {
+        return Err(Error::InvalidArguments);
+    }
+    if sig_storage.len() < k {
+        return Err(Error::OutputBufferTooSmall);
+    }
+    let em_bits = key_bits - 1;
+    if em_storage.len() < em_bits.div_ceil(8) {
+        return Err(Error::OutputBufferTooSmall);
+    }
+    let em_slice = emsa_pss_encode_into(m_hash, em_bits, salt, hash, em_storage)?;
+    let em = T::try_from_be_bytes_vartime(em_slice)?;
+    let s = crate::algorithms::rsa::rsa_private_op_and_check_blinded(rng, &em, d, e, n_params)?;
+    crate::algorithms::pad::uint_to_zeroizing_be_pad_into(s, k, sig_storage)
+}
+
 fn emsa_pss_verify_pre<'a>(
     m_hash: &[u8],
     em: &'a mut [u8],

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -1624,6 +1624,60 @@ mod private_op_tests {
         emsa_pss_verify(&digest, &mut em_copy, Some(0), &mut verify_hash, KEY_BITS).unwrap();
     }
 
+    // Exact-width blinded sign KAT on the modmath backend. Prior to
+    // modmath 0.4.1-alpha.2 this would deterministically fail with
+    // `Error::Internal` — safegcd's `2·modulus ≤ T::MAX` precondition
+    // was unmet in `U2048` for a 2048-bit modulus, so every `InvertCt`
+    // call returned `None` and the blinding retry loop exhausted. The
+    // alpha's `SignedExt`-based signed intermediates close the
+    // headroom gap without widening the caller's carrier.
+    #[test]
+    fn pss_signing_key_try_sign_prehash_with_rng_into_round_trip_2048_sha1() {
+        use crate::algorithms::pss::emsa_pss_verify;
+        use crate::key::GenericRsaPrivateKey;
+        use crate::pss::GenericSigningKey;
+        use digest::Digest;
+        use rand::rngs::ChaCha8Rng;
+        use rand_core::SeedableRng;
+        use sha1::Sha1;
+
+        type U2048 = FixedUInt<u8, 256, Ct>;
+        const K: usize = 256;
+        const KEY_BITS: usize = 2048;
+
+        let key =
+            crate::modmath_support::public_key_ct_from_be_bytes::<U2048>(&N_2048, 65537).unwrap();
+        let d = wrap_value(
+            <U2048 as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(&D_2048).unwrap(),
+        );
+        let priv_key = GenericRsaPrivateKey::from_public_and_d(key.clone(), d);
+        // Salt length = 0 → deterministic PSS encoding.
+        let signing_key = GenericSigningKey::<Sha1, _, _>::new_with_salt_len(priv_key, 0);
+
+        let msg: &[u8] = b"pss-blinded-roundtrip test message";
+        let digest = Sha1::digest(msg);
+        let mut rng = ChaCha8Rng::from_seed([42; 32]);
+        let mut em_storage = [0u8; K];
+        let mut sig_storage = [0u8; K];
+        let mut salt_storage = [0u8; 0];
+        let sig_slice = signing_key
+            .try_sign_prehash_with_rng_into(
+                &mut rng,
+                &digest,
+                &mut em_storage,
+                &mut sig_storage,
+                &mut salt_storage,
+            )
+            .unwrap();
+        assert_eq!(sig_slice.len(), K);
+
+        let recovered = public_key_op_ct(&key, sig_slice).unwrap();
+        let mut em_copy = [0u8; K];
+        em_copy.copy_from_slice(recovered.as_ref());
+        let mut verify_hash = Sha1::new();
+        emsa_pss_verify(&digest, &mut em_copy, Some(0), &mut verify_hash, KEY_BITS).unwrap();
+    }
+
     #[test]
     fn pss_signing_key_rejects_wrong_prehash_length() {
         use crate::key::GenericRsaPrivateKey;

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -11,7 +11,7 @@
 use super::pkcs1v15_generate_prefix;
 #[cfg(not(feature = "alloc"))]
 use super::{pkcs1v15_generate_prefix_helper, Prefix};
-use super::{sign_into, GenericVerifyingKey};
+use super::{sign_into, sign_with_rng_into, GenericVerifyingKey};
 use crate::{
     errors::Result,
     key::GenericRsaPrivateKey,
@@ -205,6 +205,75 @@ where
         }
         let k = self.inner.size();
         sign_into(
+            self.inner.n_params(),
+            crate::traits::keys::PrivateKeyParts::d(&self.inner),
+            self.inner.e(),
+            self.prefix.as_ref(),
+            prehash,
+            k,
+            em_storage,
+            sig_storage,
+        )
+    }
+}
+
+// RNG-taking blinded sign variants — mirror the deterministic pair
+// above but route through the blinded private op
+// (`rsa_private_op_and_check_blinded`), hiding `EM` from timing
+// analysis on `d`. Bounds add
+// `T: TryRandomMod` and `M::MontgomeryForm: InvertCt<M> + MulCt<M>`
+// — satisfied by both alloc (`BoxedUint`/`BoxedMontyParams`) and
+// modmath (`ModMathValue<T>` / `ModMathParams<T, Ct>`) backends.
+impl<D, T, M> GenericSigningKey<D, T, M>
+where
+    D: Digest,
+    T: UnsignedModularInt + Zeroize + crate::traits::modular::TryRandomMod,
+    T::Bytes: Zeroize,
+    M: ModulusParams<Modulus = T> + crate::traits::modular::CtModulusParams,
+    M::MontgomeryForm: Pow<M>
+        + PowBoundedExp<M>
+        + crate::traits::modular::InvertCt<M>
+        + crate::traits::modular::MulCt<M>,
+{
+    /// RNG-driven blinded variant of [`Self::try_sign_into`]. Uses
+    /// `rng` to sample the blinding factor per signature; hides `EM`
+    /// (the padded plaintext) from side-channel analysis on `d`.
+    pub fn try_sign_with_rng_into<'sig, R: rand_core::TryCryptoRng + ?Sized>(
+        &self,
+        rng: &mut R,
+        msg: &[u8],
+        em_storage: &mut [u8],
+        sig_storage: &'sig mut [u8],
+    ) -> Result<&'sig [u8]> {
+        let digest = D::digest(msg);
+        let k = self.inner.size();
+        sign_with_rng_into(
+            rng,
+            self.inner.n_params(),
+            crate::traits::keys::PrivateKeyParts::d(&self.inner),
+            self.inner.e(),
+            self.prefix.as_ref(),
+            digest.as_ref(),
+            k,
+            em_storage,
+            sig_storage,
+        )
+    }
+
+    /// RNG-driven blinded variant of [`Self::try_sign_prehash_into`].
+    pub fn try_sign_prehash_with_rng_into<'sig, R: rand_core::TryCryptoRng + ?Sized>(
+        &self,
+        rng: &mut R,
+        prehash: &[u8],
+        em_storage: &mut [u8],
+        sig_storage: &'sig mut [u8],
+    ) -> Result<&'sig [u8]> {
+        if prehash.len() != <D as Digest>::output_size() {
+            return Err(crate::errors::Error::InputNotHashed);
+        }
+        let k = self.inner.size();
+        sign_with_rng_into(
+            rng,
             self.inner.n_params(),
             crate::traits::keys::PrivateKeyParts::d(&self.inner),
             self.inner.e(),

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -9,7 +9,7 @@
 //! side: caller passes `&mut R: TryCryptoRng + ?Sized`.
 
 use crate::{
-    algorithms::pss::sign_into,
+    algorithms::pss::{sign_into, sign_with_rng_into},
     errors::{Error, Result},
     key::GenericRsaPrivateKey,
     traits::{
@@ -141,18 +141,26 @@ where
     }
 }
 
+// RNG-taking sign methods now use base blinding in addition to the
+// salt sampling. Bound expansion (`T: TryRandomMod`,
+// `M::MontgomeryForm: InvertCt<M> + MulCt<M>`) is satisfied by both
+// backends we support.
 impl<D, T, M> GenericSigningKey<D, T, M>
 where
     D: Digest + FixedOutputReset,
-    T: UnsignedModularInt + Zeroize,
+    T: UnsignedModularInt + Zeroize + crate::traits::modular::TryRandomMod,
     T::Bytes: Zeroize,
     M: ModulusParams<Modulus = T> + crate::traits::modular::CtModulusParams,
-    M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
+    M::MontgomeryForm: Pow<M>
+        + PowBoundedExp<M>
+        + crate::traits::modular::InvertCt<M>
+        + crate::traits::modular::MulCt<M>,
 {
     /// Sign `msg` (hashed internally with `D`) into `sig_storage`, drawing
-    /// the PSS salt from `rng`. Uses `em_storage` and `salt_storage` as
-    /// scratch. All three buffers must be at least the relevant sizes
-    /// (`em_storage`: `em_bits.div_ceil(8)`; `sig_storage`: `n.size()`;
+    /// the PSS salt AND the RSA base-blinding factor from `rng`. Uses
+    /// `em_storage` and `salt_storage` as scratch. All three buffers
+    /// must be at least the relevant sizes (`em_storage`:
+    /// `em_bits.div_ceil(8)`; `sig_storage`: `n.size()`;
     /// `salt_storage`: `self.salt_len()`).
     ///
     /// Mirrors [`crate::traits::RandomizedEncryptor::encrypt_with_rng_into`]:
@@ -176,7 +184,8 @@ where
     }
 
     /// Sign a precomputed `prehash` (`D::output_size()` bytes) into
-    /// `sig_storage`, drawing the PSS salt from `rng`.
+    /// `sig_storage`, drawing the PSS salt AND the RSA base-blinding
+    /// factor from `rng`.
     ///
     /// Returns [`Error::InputNotHashed`] if `prehash.len()` doesn't match
     /// `D::output_size()`. Returns [`Error::OutputBufferTooSmall`] if
@@ -197,7 +206,8 @@ where
             .ok_or(Error::OutputBufferTooSmall)?;
         rng.try_fill_bytes(salt).map_err(|_| Error::Rng)?;
         let mut hash = D::new();
-        sign_into(
+        sign_with_rng_into(
+            rng,
             self.inner.n_params(),
             crate::traits::keys::PrivateKeyParts::d(&self.inner),
             self.inner.e(),
@@ -209,7 +219,20 @@ where
             sig_storage,
         )
     }
+}
 
+// Deterministic (caller-supplied salt, no RNG) variant kept in a
+// separate impl block so it doesn't require the blinding bounds —
+// callers who explicitly want a deterministic sign path (typically
+// tests) don't need the extra trait impls on `T` / `M`.
+impl<D, T, M> GenericSigningKey<D, T, M>
+where
+    D: Digest + FixedOutputReset,
+    T: UnsignedModularInt + Zeroize,
+    T::Bytes: Zeroize,
+    M: ModulusParams<Modulus = T> + crate::traits::modular::CtModulusParams,
+    M::MontgomeryForm: Pow<M> + PowBoundedExp<M>,
+{
     /// Sign with caller-supplied salt — useful for determinism in tests.
     ///
     /// Returns [`Error::InputNotHashed`] if `prehash.len()` doesn't match

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -300,33 +300,8 @@ mod tests {
         use sha2::Sha256;
         use signature::Verifier;
 
-        const PRIV_KEY_PKCS1_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAwQe5brkkpxrwR/5TJ6JXsUyBzYtbEL/w8u8P6NnxQ8sL4KYp
-MzzTB6aq1gq7bieYXChg0PIWeTukGaOzZe96KxhT0GbhhYRlukktM/quRrM7nYdm
-UmXo7+KWU55kfcNOjWKADL/7qmxn6y/+kPmBg83nHdr1Mq6/pNkeHY/1CeGGECl0
-rg7gfEkssHjZw/uKafA271fX9A/q3LcAeWi7iA01PgmP28BrWb7OQoYVY71kFY11
-e919VlMh8oXsIV0nXCkYu9dR8Pzq6U4gFASK32fFkKX/djRMljEgss3kR0SWPH7t
-m5uXX1wRTJ2mRaZh/BmGweIvYCZ5y0+9ESOD1wIDAQABAoIBAAj3NuGxr8YjNi3h
-3jLlE3WkvBKz+lLY13QxLmf+V3pyn+abUSaUGKkuUJkIfpQrOqRtK7IIzIps/r5C
-ID8H1IDT7HCtlqQA9kikxXi4mAeoo4g5lcMWAK/Dsn/Hx5sfyzI99PyininYRyth
-W02YiS96DNYSKXllLHmXrBJrcVI4FqXAz5s7MezU0XYi+jeaVGEP2bd2cHfQJki/
-pLOKBvA5DGT7HbmMV7Z1qg/zcr/4Py+7qAFC5XsbQIILSMTfC45QFgs1lApnUG8H
-uIhf5lgZ8m0ouDBb/e1Q04ANtdLLI6EmrR11PwavUmvPvXuedXkv2OvnuAbiJr6g
-j0I0VaECgYEAyWf2QZrEoZLzVrInZ+VYtov1+jjgFcxW9lHuCJXtTx8hFla13Bmp
-bc8PoxWb+37jPdrOYPW0yv1sk5VeVkxOJbms0Gn8hpyI+0muQZ3jmwlS0A10T6FL
-wWECYvrxO8DCaVCQ4V+egLSDb/GMkRgHJF3Dr7g3ep7krXf2eeWILQUCgYEA9VqJ
-ijMDKw/KX6swyMe3A1nA0MlLBeseXxrwNIJenwRXCzjG3BH6oHW2MGwH0EV7sSoG
-FR6j7LZbp9I9NvRcAYU/s1qiAX3iX3KIsbZYNtEC6tKn/HClaHLZOhyuE8tjshyD
-jhK/0rhw7R5VQ1GfJhmuzvwoMFTA0fqZBQpWZCsCgYBA5WO+3dyv50bLT5pM6uR7
-5Xs7xinGPFJlCh812wFdNj2WEhiFNCuYu1hhhyv8jHUyUBehvGol4iSjJUUBb5La
-qwpZGV2KDlRBDAu/Dt3w7b8mVL9+jQ144QZA2HT0ePbrsk8Mn5/V/tQ/NMjDU8ex
-WxkbvLL7qskqb/YWbvRC9QKBgQDUJYvFpmQ36LhozmIpSZ6yU/oHzfWD0Y/6VhWa
-oZtlTeBhwJ8aDKWz9vQonFCJQns4bgjCXDMLa4aG7p+lk9a2LdwtndF1Dr8dHrCZ
-UPynsUQffTRpb5FmZd/0gnX2gafbixIpV4brkjV6of7BbaL50702Fgw99hqftVp4
-ZD7c7wKBgD7uIs6rgpaJzKbf7ejjZSjfLOgHlJhtH6Nejp8KoJRsEQI1ofWyIn7D
-eMjIuecwLapPwjY2G0/sUW61bqrxgW10wDJHPNllGsZFanzpb7x5o/7eNhzc4qNf
-Rmb665iB5fwpqmbE/hYKIn7asYQE+V0dkgt8M3qvlJJ5JJbCrJx3
------END RSA PRIVATE KEY-----";
+        const PRIV_KEY_PKCS1_PEM: &str =
+            include_str!("../../tests/examples/pkcs1/rsa2048-priv.pem");
 
         let priv_key = RsaPrivateKey::from_pkcs1_pem(PRIV_KEY_PKCS1_PEM).unwrap();
         let signing_key = SigningKey::<Sha256>::new(priv_key.clone());

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -283,6 +283,78 @@ where
 
 #[cfg(test)]
 mod tests {
+    // End-to-end KAT for the heapless-shaped `try_sign_with_rng_into`
+    // wrapper on `pss::SigningKey<D>`. Exercises the full stack:
+    // wrapper (which internally samples salt AND blinding `r`) →
+    // `algorithms::pss::sign_with_rng_into` →
+    // `rsa_private_op_and_check_blinded` → `TryRandomMod` →
+    // `rsa_private_op_blinded` (InvertCt/MulCt).
+    #[test]
+    #[cfg(feature = "encoding")]
+    fn signing_key_try_sign_with_rng_into_round_trip() {
+        use super::*;
+        use crate::pss::VerifyingKey;
+        use pkcs1::DecodeRsaPrivateKey;
+        use rand::rngs::ChaCha8Rng;
+        use rand_core::SeedableRng;
+        use sha2::Sha256;
+        use signature::Verifier;
+
+        const PRIV_KEY_PKCS1_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwQe5brkkpxrwR/5TJ6JXsUyBzYtbEL/w8u8P6NnxQ8sL4KYp
+MzzTB6aq1gq7bieYXChg0PIWeTukGaOzZe96KxhT0GbhhYRlukktM/quRrM7nYdm
+UmXo7+KWU55kfcNOjWKADL/7qmxn6y/+kPmBg83nHdr1Mq6/pNkeHY/1CeGGECl0
+rg7gfEkssHjZw/uKafA271fX9A/q3LcAeWi7iA01PgmP28BrWb7OQoYVY71kFY11
+e919VlMh8oXsIV0nXCkYu9dR8Pzq6U4gFASK32fFkKX/djRMljEgss3kR0SWPH7t
+m5uXX1wRTJ2mRaZh/BmGweIvYCZ5y0+9ESOD1wIDAQABAoIBAAj3NuGxr8YjNi3h
+3jLlE3WkvBKz+lLY13QxLmf+V3pyn+abUSaUGKkuUJkIfpQrOqRtK7IIzIps/r5C
+ID8H1IDT7HCtlqQA9kikxXi4mAeoo4g5lcMWAK/Dsn/Hx5sfyzI99PyininYRyth
+W02YiS96DNYSKXllLHmXrBJrcVI4FqXAz5s7MezU0XYi+jeaVGEP2bd2cHfQJki/
+pLOKBvA5DGT7HbmMV7Z1qg/zcr/4Py+7qAFC5XsbQIILSMTfC45QFgs1lApnUG8H
+uIhf5lgZ8m0ouDBb/e1Q04ANtdLLI6EmrR11PwavUmvPvXuedXkv2OvnuAbiJr6g
+j0I0VaECgYEAyWf2QZrEoZLzVrInZ+VYtov1+jjgFcxW9lHuCJXtTx8hFla13Bmp
+bc8PoxWb+37jPdrOYPW0yv1sk5VeVkxOJbms0Gn8hpyI+0muQZ3jmwlS0A10T6FL
+wWECYvrxO8DCaVCQ4V+egLSDb/GMkRgHJF3Dr7g3ep7krXf2eeWILQUCgYEA9VqJ
+ijMDKw/KX6swyMe3A1nA0MlLBeseXxrwNIJenwRXCzjG3BH6oHW2MGwH0EV7sSoG
+FR6j7LZbp9I9NvRcAYU/s1qiAX3iX3KIsbZYNtEC6tKn/HClaHLZOhyuE8tjshyD
+jhK/0rhw7R5VQ1GfJhmuzvwoMFTA0fqZBQpWZCsCgYBA5WO+3dyv50bLT5pM6uR7
+5Xs7xinGPFJlCh812wFdNj2WEhiFNCuYu1hhhyv8jHUyUBehvGol4iSjJUUBb5La
+qwpZGV2KDlRBDAu/Dt3w7b8mVL9+jQ144QZA2HT0ePbrsk8Mn5/V/tQ/NMjDU8ex
+WxkbvLL7qskqb/YWbvRC9QKBgQDUJYvFpmQ36LhozmIpSZ6yU/oHzfWD0Y/6VhWa
+oZtlTeBhwJ8aDKWz9vQonFCJQns4bgjCXDMLa4aG7p+lk9a2LdwtndF1Dr8dHrCZ
+UPynsUQffTRpb5FmZd/0gnX2gafbixIpV4brkjV6of7BbaL50702Fgw99hqftVp4
+ZD7c7wKBgD7uIs6rgpaJzKbf7ejjZSjfLOgHlJhtH6Nejp8KoJRsEQI1ofWyIn7D
+eMjIuecwLapPwjY2G0/sUW61bqrxgW10wDJHPNllGsZFanzpb7x5o/7eNhzc4qNf
+Rmb665iB5fwpqmbE/hYKIn7asYQE+V0dkgt8M3qvlJJ5JJbCrJx3
+-----END RSA PRIVATE KEY-----";
+
+        let priv_key = RsaPrivateKey::from_pkcs1_pem(PRIV_KEY_PKCS1_PEM).unwrap();
+        let signing_key = SigningKey::<Sha256>::new(priv_key.clone());
+        let verifying_key = VerifyingKey::<Sha256>::new(priv_key.to_public_key());
+
+        let msg: &[u8] = b"blinded pss sign test message";
+        let mut rng = ChaCha8Rng::from_seed([42; 32]);
+
+        // 2048-bit key → 256-byte signature and EM;
+        // salt_len defaults to `Sha256::output_size()` = 32.
+        let mut em_storage = [0u8; 256];
+        let mut sig_storage = [0u8; 256];
+        let mut salt_storage = [0u8; 32];
+        let sig_slice = signing_key
+            .try_sign_with_rng_into(
+                &mut rng,
+                msg,
+                &mut em_storage,
+                &mut sig_storage,
+                &mut salt_storage,
+            )
+            .unwrap();
+        assert_eq!(sig_slice.len(), 256);
+
+        let sig = Signature::try_from(sig_slice).unwrap();
+        verifying_key.verify(msg, &sig).unwrap();
+    }
+
     #[test]
     #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {

--- a/tests/pkcs1v15.rs
+++ b/tests/pkcs1v15.rs
@@ -78,3 +78,66 @@ Rmb665iB5fwpqmbE/hYKIn7asYQE+V0dkgt8M3qvlJJ5JJbCrJx3
         .verify(msg, &sig_via_new)
         .is_ok());
 }
+
+// End-to-end KAT for the heapless-shaped `try_sign_with_rng_into`
+// wrapper on `pkcs1v15::SigningKey<D>`. Exercises the full stack:
+// wrapper → `algorithms::pkcs1v15::sign_with_rng_into` →
+// `rsa_private_op_and_check_blinded` → `TryRandomMod` (r sampling) →
+// `rsa_private_op_blinded` (InvertCt/MulCt). Uses the same PEM
+// keypair as `signing_key_new_same_as_from` for repeatability.
+#[cfg(feature = "encoding")]
+#[test]
+fn signing_key_try_sign_with_rng_into_round_trip() {
+    use pkcs1::DecodeRsaPrivateKey;
+    use rand::rngs::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use rsa::pkcs1v15::{Signature, SigningKey};
+    use rsa::RsaPrivateKey;
+    use signature::{Keypair, Verifier};
+
+    const PRIV_KEY_PKCS1_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwQe5brkkpxrwR/5TJ6JXsUyBzYtbEL/w8u8P6NnxQ8sL4KYp
+MzzTB6aq1gq7bieYXChg0PIWeTukGaOzZe96KxhT0GbhhYRlukktM/quRrM7nYdm
+UmXo7+KWU55kfcNOjWKADL/7qmxn6y/+kPmBg83nHdr1Mq6/pNkeHY/1CeGGECl0
+rg7gfEkssHjZw/uKafA271fX9A/q3LcAeWi7iA01PgmP28BrWb7OQoYVY71kFY11
+e919VlMh8oXsIV0nXCkYu9dR8Pzq6U4gFASK32fFkKX/djRMljEgss3kR0SWPH7t
+m5uXX1wRTJ2mRaZh/BmGweIvYCZ5y0+9ESOD1wIDAQABAoIBAAj3NuGxr8YjNi3h
+3jLlE3WkvBKz+lLY13QxLmf+V3pyn+abUSaUGKkuUJkIfpQrOqRtK7IIzIps/r5C
+ID8H1IDT7HCtlqQA9kikxXi4mAeoo4g5lcMWAK/Dsn/Hx5sfyzI99PyininYRyth
+W02YiS96DNYSKXllLHmXrBJrcVI4FqXAz5s7MezU0XYi+jeaVGEP2bd2cHfQJki/
+pLOKBvA5DGT7HbmMV7Z1qg/zcr/4Py+7qAFC5XsbQIILSMTfC45QFgs1lApnUG8H
+uIhf5lgZ8m0ouDBb/e1Q04ANtdLLI6EmrR11PwavUmvPvXuedXkv2OvnuAbiJr6g
+j0I0VaECgYEAyWf2QZrEoZLzVrInZ+VYtov1+jjgFcxW9lHuCJXtTx8hFla13Bmp
+bc8PoxWb+37jPdrOYPW0yv1sk5VeVkxOJbms0Gn8hpyI+0muQZ3jmwlS0A10T6FL
+wWECYvrxO8DCaVCQ4V+egLSDb/GMkRgHJF3Dr7g3ep7krXf2eeWILQUCgYEA9VqJ
+ijMDKw/KX6swyMe3A1nA0MlLBeseXxrwNIJenwRXCzjG3BH6oHW2MGwH0EV7sSoG
+FR6j7LZbp9I9NvRcAYU/s1qiAX3iX3KIsbZYNtEC6tKn/HClaHLZOhyuE8tjshyD
+jhK/0rhw7R5VQ1GfJhmuzvwoMFTA0fqZBQpWZCsCgYBA5WO+3dyv50bLT5pM6uR7
+5Xs7xinGPFJlCh812wFdNj2WEhiFNCuYu1hhhyv8jHUyUBehvGol4iSjJUUBb5La
+qwpZGV2KDlRBDAu/Dt3w7b8mVL9+jQ144QZA2HT0ePbrsk8Mn5/V/tQ/NMjDU8ex
+WxkbvLL7qskqb/YWbvRC9QKBgQDUJYvFpmQ36LhozmIpSZ6yU/oHzfWD0Y/6VhWa
+oZtlTeBhwJ8aDKWz9vQonFCJQns4bgjCXDMLa4aG7p+lk9a2LdwtndF1Dr8dHrCZ
+UPynsUQffTRpb5FmZd/0gnX2gafbixIpV4brkjV6of7BbaL50702Fgw99hqftVp4
+ZD7c7wKBgD7uIs6rgpaJzKbf7ejjZSjfLOgHlJhtH6Nejp8KoJRsEQI1ofWyIn7D
+eMjIuecwLapPwjY2G0/sUW61bqrxgW10wDJHPNllGsZFanzpb7x5o/7eNhzc4qNf
+Rmb665iB5fwpqmbE/hYKIn7asYQE+V0dkgt8M3qvlJJ5JJbCrJx3
+-----END RSA PRIVATE KEY-----";
+
+    let priv_key = RsaPrivateKey::from_pkcs1_pem(PRIV_KEY_PKCS1_PEM).unwrap();
+    let signing_key = SigningKey::<sha2::Sha256>::new(priv_key);
+    let verifying_key = signing_key.verifying_key();
+
+    let msg: &[u8] = b"blinded sign test message";
+    let mut rng = ChaCha8Rng::from_seed([42; 32]);
+
+    // 2048-bit key → 256-byte signature and EM.
+    let mut em_storage = [0u8; 256];
+    let mut sig_storage = [0u8; 256];
+    let sig_slice = signing_key
+        .try_sign_with_rng_into(&mut rng, msg, &mut em_storage, &mut sig_storage)
+        .unwrap();
+    assert_eq!(sig_slice.len(), 256);
+
+    let sig = Signature::try_from(sig_slice).unwrap();
+    verifying_key.verify(msg, &sig).unwrap();
+}

--- a/tests/pkcs1v15.rs
+++ b/tests/pkcs1v15.rs
@@ -83,8 +83,7 @@ Rmb665iB5fwpqmbE/hYKIn7asYQE+V0dkgt8M3qvlJJ5JJbCrJx3
 // wrapper on `pkcs1v15::SigningKey<D>`. Exercises the full stack:
 // wrapper → `algorithms::pkcs1v15::sign_with_rng_into` →
 // `rsa_private_op_and_check_blinded` → `TryRandomMod` (r sampling) →
-// `rsa_private_op_blinded` (InvertCt/MulCt). Uses the same PEM
-// keypair as `signing_key_new_same_as_from` for repeatability.
+// `rsa_private_op_blinded` (InvertCt/MulCt).
 #[cfg(feature = "encoding")]
 #[test]
 fn signing_key_try_sign_with_rng_into_round_trip() {
@@ -95,33 +94,7 @@ fn signing_key_try_sign_with_rng_into_round_trip() {
     use rsa::RsaPrivateKey;
     use signature::{Keypair, Verifier};
 
-    const PRIV_KEY_PKCS1_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAwQe5brkkpxrwR/5TJ6JXsUyBzYtbEL/w8u8P6NnxQ8sL4KYp
-MzzTB6aq1gq7bieYXChg0PIWeTukGaOzZe96KxhT0GbhhYRlukktM/quRrM7nYdm
-UmXo7+KWU55kfcNOjWKADL/7qmxn6y/+kPmBg83nHdr1Mq6/pNkeHY/1CeGGECl0
-rg7gfEkssHjZw/uKafA271fX9A/q3LcAeWi7iA01PgmP28BrWb7OQoYVY71kFY11
-e919VlMh8oXsIV0nXCkYu9dR8Pzq6U4gFASK32fFkKX/djRMljEgss3kR0SWPH7t
-m5uXX1wRTJ2mRaZh/BmGweIvYCZ5y0+9ESOD1wIDAQABAoIBAAj3NuGxr8YjNi3h
-3jLlE3WkvBKz+lLY13QxLmf+V3pyn+abUSaUGKkuUJkIfpQrOqRtK7IIzIps/r5C
-ID8H1IDT7HCtlqQA9kikxXi4mAeoo4g5lcMWAK/Dsn/Hx5sfyzI99PyininYRyth
-W02YiS96DNYSKXllLHmXrBJrcVI4FqXAz5s7MezU0XYi+jeaVGEP2bd2cHfQJki/
-pLOKBvA5DGT7HbmMV7Z1qg/zcr/4Py+7qAFC5XsbQIILSMTfC45QFgs1lApnUG8H
-uIhf5lgZ8m0ouDBb/e1Q04ANtdLLI6EmrR11PwavUmvPvXuedXkv2OvnuAbiJr6g
-j0I0VaECgYEAyWf2QZrEoZLzVrInZ+VYtov1+jjgFcxW9lHuCJXtTx8hFla13Bmp
-bc8PoxWb+37jPdrOYPW0yv1sk5VeVkxOJbms0Gn8hpyI+0muQZ3jmwlS0A10T6FL
-wWECYvrxO8DCaVCQ4V+egLSDb/GMkRgHJF3Dr7g3ep7krXf2eeWILQUCgYEA9VqJ
-ijMDKw/KX6swyMe3A1nA0MlLBeseXxrwNIJenwRXCzjG3BH6oHW2MGwH0EV7sSoG
-FR6j7LZbp9I9NvRcAYU/s1qiAX3iX3KIsbZYNtEC6tKn/HClaHLZOhyuE8tjshyD
-jhK/0rhw7R5VQ1GfJhmuzvwoMFTA0fqZBQpWZCsCgYBA5WO+3dyv50bLT5pM6uR7
-5Xs7xinGPFJlCh812wFdNj2WEhiFNCuYu1hhhyv8jHUyUBehvGol4iSjJUUBb5La
-qwpZGV2KDlRBDAu/Dt3w7b8mVL9+jQ144QZA2HT0ePbrsk8Mn5/V/tQ/NMjDU8ex
-WxkbvLL7qskqb/YWbvRC9QKBgQDUJYvFpmQ36LhozmIpSZ6yU/oHzfWD0Y/6VhWa
-oZtlTeBhwJ8aDKWz9vQonFCJQns4bgjCXDMLa4aG7p+lk9a2LdwtndF1Dr8dHrCZ
-UPynsUQffTRpb5FmZd/0gnX2gafbixIpV4brkjV6of7BbaL50702Fgw99hqftVp4
-ZD7c7wKBgD7uIs6rgpaJzKbf7ejjZSjfLOgHlJhtH6Nejp8KoJRsEQI1ofWyIn7D
-eMjIuecwLapPwjY2G0/sUW61bqrxgW10wDJHPNllGsZFanzpb7x5o/7eNhzc4qNf
-Rmb665iB5fwpqmbE/hYKIn7asYQE+V0dkgt8M3qvlJJ5JJbCrJx3
------END RSA PRIVATE KEY-----";
+    const PRIV_KEY_PKCS1_PEM: &str = include_str!("examples/pkcs1/rsa2048-priv.pem");
 
     let priv_key = RsaPrivateKey::from_pkcs1_pem(PRIV_KEY_PKCS1_PEM).unwrap();
     let signing_key = SigningKey::<sha2::Sha256>::new(priv_key);


### PR DESCRIPTION
## Summary

Threads the base-blinding RNG through the `sign_into` surface so callers can opt in to `rsa_private_op_and_check_blinded` at the wrapper layer. Sibling APIs — existing deterministic `try_sign_into` callers keep their behavior.

**Layer 1 — algorithm primitives (`sign_with_rng_into`):**
- `algorithms::pkcs1v15::sign_with_rng_into` — RSASSA-PKCS1-v1_5 sign routed through the blinded private op.
- `algorithms::pss::sign_with_rng_into` — RSASSA-PSS sign, same routing. PSS's existing salt-RNG parameter is reused for the blinding factor.

Bound expansion on both: `T: TryRandomMod`, `M::MontgomeryForm: InvertCt<M> + MulCt<M>`, `M: CtModulusParams`. Satisfied by both backends (alloc `BoxedUint`/`BoxedMontyParams` and modmath `ModMathValue<T>`/`ModMathParams<T, Ct>`).

**Layer 2 — wrappers (`try_sign_with_rng_into`):**
- `pkcs1v15::GenericSigningKey::{try_sign_with_rng_into, try_sign_prehash_with_rng_into}` — new impl block with the expanded bounds so the deterministic sign path stays unaffected.
- `pss::GenericSigningKey::{try_sign_with_rng_into, try_sign_prehash_with_rng_into}` — split into a separate impl block from the deterministic salt-supplied variant (`try_sign_prehash_with_salt_into`), which keeps its narrower bounds.

**End-to-end KATs** using the existing 2048-bit PEM keypair from `signing_key_new_same_as_from`:
- `tests/pkcs1v15.rs::signing_key_try_sign_with_rng_into_round_trip`
- `src/pss/signing_key.rs::signing_key_try_sign_with_rng_into_round_trip`

Closes out the wip-private-key blinding graduation series (#41–#45): the primitives are now consumable through the `SigningKey<D>` shape that `signature::RandomizedSigner` consumers already use.

## Test plan
- [x] `cargo check` (default) / `--no-default-features --features modmath` / `--no-default-features --features "modmath wip-private-key"`
- [x] `cargo test --lib` and `cargo test --test pkcs1v15`
- [x] `cargo clippy --all -- -D warnings`

## Summary by Sourcery

Add RNG-driven blinded RSA signing variants to PKCS#1 v1.5 and PSS primitives and expose them through GenericSigningKey wrappers, keeping existing deterministic paths unchanged.

New Features:
- Introduce RNG-taking `sign_with_rng_into` primitives for PKCS#1 v1.5 and PSS that route private-key operations through blinded RSA.
- Expose `try_sign_with_rng_into` and prehash variants on PKCS#1 v1.5 and PSS `GenericSigningKey` to opt into blinded signing via the existing SigningKey shape.

Tests:
- Add end-to-end round-trip tests for PKCS#1 v1.5 and PSS `SigningKey` RNG-based blinded signing using a fixed 2048-bit PEM keypair.