### PR TITLE
Retire wip-private-key and private-key; add keygen feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,8 @@ name = "rsa_decrypt"
 required-features = ["modmath", "alloc"]
 
 [features]
-default = ["std", "encoding", "modmath"]
-encoding = ["alloc", "private-key", "dep:pkcs1", "dep:pkcs8", "dep:spki"]
+default = ["std", "encoding", "modmath", "keygen"]
+encoding = ["alloc", "dep:pkcs1", "dep:pkcs8", "dep:spki"]
 hazmat = []
 getrandom = ["dep:crypto-bigint", "crypto-bigint/getrandom", "crypto-common"]
 serde = ["encoding", "dep:serde", "dep:serdect", "dep:crypto-bigint", "crypto-bigint/serde"]
@@ -93,15 +93,12 @@ pkcs5 = ["pkcs8/encryption"]
 std = ["alloc", "pkcs1?/std", "pkcs8?/std"]
 alloc = ["dep:crypto-bigint", "crypto-bigint/alloc", "pkcs8/alloc", "spki/alloc", "digest/alloc", "signature/alloc", "zeroize/alloc"]
 
-# Enable private key support, doesn't work with no-alloc
-private-key = ["alloc", "dep:crypto-primes"]
+# On-device key generation (`RsaPrivateKey::new` and friends). Pulls the
+# heavy `crypto-primes` stack; never available on the no-alloc path —
+# heapless targets get keys from a provisioning path (PEM/HSM/firmware
+# constants), not generated on-device.
+keygen = ["alloc", "dep:crypto-primes"]
 modmath = ["dep:modmath", "dep:modmath-cios", "dep:fixed-bigint"]
-
-# In-progress: gate for individual private-key functions that have been
-# generalized to work on the no_alloc / modmath path. Enabling this alone
-# (without `private-key`) compiles and tests the ported subset; enabling
-# both gives you the full alloc-bound surface plus any newly ported items.
-wip-private-key = []
 
 [package.metadata.docs.rs]
 features = ["std", "serde", "hazmat", "sha2"]

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![Cortex-M](https://github.com/kaidokert/RSA/actions/workflows/cortex_m.yml/badge.svg)](https://github.com/kaidokert/RSA/actions/workflows/cortex_m.yml)
 [![RISC-V](https://github.com/kaidokert/RSA/actions/workflows/riscv.yml/badge.svg)](https://github.com/kaidokert/RSA/actions/workflows/riscv.yml)
 
-A microcontroller-friendly fork of the [RustCrypto RSA crate](https://github.com/RustCrypto/RSA). Public-key operations — PKCS#1 v1.5 verify, OAEP encrypt, PSS verify — are generic over the bigint backend, with a no-alloc path through [fixed-bigint](https://crates.io/crates/fixed-bigint) and [modmath](https://crates.io/crates/modmath) tested on 8-bit AVR, Cortex-M and RISC-V.
+A microcontroller-friendly fork of the [RustCrypto RSA crate](https://github.com/RustCrypto/RSA). RSA operations — PKCS#1 v1.5 verify and sign, PSS verify and sign, OAEP encrypt — are generic over the bigint backend, with a no-alloc path through [fixed-bigint](https://crates.io/crates/fixed-bigint) and [modmath](https://crates.io/crates/modmath) tested on 8-bit AVR, Cortex-M and RISC-V.
 
 #### Scope
 
-This is a proof of concept focused on shrinking code size and stack usage. Public-key only — verification and encryption — which covers the common embedded use cases (bootloader signature checks, key wrapping to a server).
+Focused on shrinking code size and stack usage. The heapless path covers public-key operations — PKCS#1 v1.5 verify, OAEP encrypt, PSS verify — and private-key signing (PKCS#1 v1.5 and PSS, the TLS 1.3 client-certificate algorithms). Signing runs constant-time in the private exponent via the `Ct`-personality modmath backend, with optional per-signature RSA base blinding (`try_sign_with_rng_into`) as defense in depth.
 
-Private-key operations (key generation, signing, decryption) are deliberately omitted from the heapless path on safety grounds: doing them correctly requires constant-time primitives, a trustworthy RNG, and secure key storage that the dependency stack doesn't yet provide. The full upstream behavior remains available via the `alloc` and `private-key` feature flags on a heap-allocating backend; license, MSRV, and security advisories there follow the upstream crate, preserved verbatim in [`UPSTREAM_README.md`](UPSTREAM_README.md).
+Key generation stays off the heapless path — it needs the heavy `crypto-primes` stack, and embedded keys arrive from a provisioning path (PEM/PKCS#8, HSM, firmware constants) rather than being generated on-device. It is available behind the `keygen` feature (on by default) on the heap-allocating backend. Decryption on the heapless path is out of scope. Full upstream behavior remains available via the `alloc` feature; license, MSRV, and security advisories there follow the upstream crate, preserved verbatim in [`UPSTREAM_README.md`](UPSTREAM_README.md).
 
 #### Resource usage (as of version 0.10.0-rc.18)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A microcontroller-friendly fork of the [RustCrypto RSA crate](https://github.com
 
 #### Scope
 
-Focused on shrinking code size and stack usage. The heapless path covers public-key operations — PKCS#1 v1.5 verify, OAEP encrypt, PSS verify — and private-key signing (PKCS#1 v1.5 and PSS, the TLS 1.3 client-certificate algorithms). Signing runs constant-time in the private exponent via the `Ct`-personality modmath backend, with optional per-signature RSA base blinding (`try_sign_with_rng_into`) as defense in depth.
+Focused on shrinking code size and stack usage. The heapless path covers verify (PKCS#1 v1.5, PSS), OAEP encrypt, and sign (PKCS#1 v1.5, PSS) — constant-time in the private exponent, with optional per-signature blinding.
 
 Key generation stays off the heapless path — it needs the heavy `crypto-primes` stack, and embedded keys arrive from a provisioning path (PEM/PKCS#8, HSM, firmware constants) rather than being generated on-device. It is available behind the `keygen` feature (on by default) on the heap-allocating backend. Decryption on the heapless path is out of scope. Full upstream behavior remains available via the `alloc` feature; license, MSRV, and security advisories there follow the upstream crate, preserved verbatim in [`UPSTREAM_README.md`](UPSTREAM_README.md).
 

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -2,7 +2,7 @@
 
 mod mgf;
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "keygen")]
 pub(crate) mod generate;
 pub(crate) mod oaep;
 pub(crate) mod pad;

--- a/src/algorithms/generate.rs
+++ b/src/algorithms/generate.rs
@@ -132,7 +132,7 @@ fn generate_prime_with_rng<R: CryptoRng + ?Sized>(rng: &mut R, bit_length: u32) 
 }
 
 #[cfg(test)]
-#[cfg(feature = "private-key")]
+#[cfg(feature = "keygen")]
 mod tests {
     use super::*;
     use rand::rngs::ChaCha8Rng;

--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -15,7 +15,6 @@ use rand_core::TryCryptoRng;
 use zeroize::Zeroizing;
 
 use crate::errors::{Error, Result};
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 use crate::traits::{
     modular::{ModulusParams, Pow, PowBoundedExp},
     UnsignedModularInt,
@@ -202,7 +201,6 @@ pub fn pkcs1v15_sign_pad_into<'a>(
 // Consumer (the heapless `SigningKey<D>` wrapper) lands in a later PR.
 #[allow(dead_code)]
 #[allow(clippy::too_many_arguments)] // Composing four byte/integer steps; splitting helps nothing.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub fn sign_into<'sig, T, M>(
     n_params: &M,
     d: &T,
@@ -252,11 +250,7 @@ where
 ///
 /// Raw RSA. Must be wrapped in a padding/signature scheme. See
 /// [module-level docs][crate::hazmat].
-// Consumer (the heapless `SigningKey<D>` wrapper) lands in the same
-// PR that adds this.
-#[allow(dead_code)]
 #[allow(clippy::too_many_arguments)]
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub fn sign_with_rng_into<'sig, R, T, M>(
     rng: &mut R,
     n_params: &M,

--- a/src/algorithms/pss.rs
+++ b/src/algorithms/pss.rs
@@ -16,7 +16,6 @@ use digest::{Digest, FixedOutputReset};
 
 use super::mgf::{mgf1_xor, mgf1_xor_digest};
 use crate::errors::{Error, Result};
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 use crate::traits::{
     modular::{ModulusParams, Pow, PowBoundedExp},
     UnsignedModularInt,
@@ -219,7 +218,6 @@ where
 // Consumer (the heapless `pss::SigningKey<D>` wrapper) lands in a later PR.
 #[allow(dead_code)]
 #[allow(clippy::too_many_arguments)] // Composing four byte/integer steps; splitting helps nothing.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub fn sign_into<'sig, T, M, D>(
     n_params: &M,
     d: &T,
@@ -281,9 +279,7 @@ where
 ///
 /// Raw RSA. Must be wrapped in a padding/signature scheme. See
 /// [module-level docs][crate::hazmat].
-#[allow(dead_code)]
 #[allow(clippy::too_many_arguments)]
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub fn sign_with_rng_into<'sig, R, T, M, D>(
     rng: &mut R,
     n_params: &M,

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -1,23 +1,23 @@
 //! Generic RSA implementation
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use core::cmp::Ordering;
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crypto_bigint::Resize as _;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
     BoxedUint, ConcatenatingMul, ConcatenatingSquare, Gcd, RandomMod,
 };
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crypto_bigint::{NonZero as CryptoNonZero, Odd as CryptoOdd};
 use rand_core::TryCryptoRng;
 use zeroize::Zeroize;
 
-#[cfg(not(feature = "private-key"))]
+#[cfg(not(feature = "alloc"))]
 use crate::traits::keys::PublicKeyParts;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::traits::keys::{PrivateKeyParts, PublicKeyParts};
 use crate::{
     errors::{Error, Result},
@@ -54,7 +54,7 @@ where
 ///
 /// Use this function with great care! Raw RSA should never be used without an appropriate padding
 /// or signature scheme. See the [module-level documentation][crate::hazmat] for more information.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub fn rsa_decrypt<R: TryCryptoRng + ?Sized>(
     rng: Option<&mut R>,
@@ -180,7 +180,7 @@ pub fn rsa_decrypt<R: TryCryptoRng + ?Sized>(
 ///
 /// Use this function with great care! Raw RSA should never be used without an appropriate padding
 /// or signature scheme. See the [module-level documentation][crate::hazmat] for more information.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub fn rsa_decrypt_and_check<R: TryCryptoRng + ?Sized>(
     priv_key: &impl PrivateKeyParts<BoxedUint, MontyParams = BoxedMontyParams>,
@@ -201,7 +201,7 @@ pub fn rsa_decrypt_and_check<R: TryCryptoRng + ?Sized>(
 }
 
 /// Returns the blinded c, along with the unblinding factor.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 fn blind<R: TryCryptoRng + ?Sized, K: PublicKeyParts<BoxedUint, MontyParams = BoxedMontyParams>>(
     rng: &mut R,
     key: &K,
@@ -244,7 +244,7 @@ fn blind<R: TryCryptoRng + ?Sized, K: PublicKeyParts<BoxedUint, MontyParams = Bo
 }
 
 /// Given an m and unblinding factor, unblind the m.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 fn unblind(m: &BoxedUint, unblinder: &BoxedUint, n_params: &BoxedMontyParams) -> BoxedUint {
     // m * r^-1 (mod n)
     debug_assert_eq!(
@@ -273,7 +273,6 @@ fn unblind(m: &BoxedUint, unblinder: &BoxedUint, n_params: &BoxedMontyParams) ->
 /// Raw RSA must be wrapped in a padding/signature scheme (PKCS#1 v1.5, PSS,
 /// OAEP) to be secure. See the [module-level documentation][crate::hazmat]
 /// for more information.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 #[inline]
 pub fn rsa_private_op<T, M>(c: &T, d: &T, n_params: &M) -> T
 where
@@ -296,7 +295,6 @@ where
 /// for more information.
 // Consumer (the heapless `pkcs1v15` / `pss` sign port) lands in a later PR.
 #[allow(dead_code)]
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 #[inline]
 pub fn rsa_private_op_and_check<T, M>(c: &T, d: &T, e: &T, n_params: &M) -> Result<T>
 where
@@ -371,7 +369,6 @@ where
 // Consumer (the RNG-taking `rsa_private_op_and_check(rng, ...)` extension
 // + heapless sign wrappers) lands in a later PR.
 #[allow(dead_code)]
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub fn rsa_private_op_blinded<T, M>(blinding_r: &T, c: &T, d: &T, e: &T, n_params: &M) -> Result<T>
 where
     T: UnsignedModularInt,
@@ -438,7 +435,6 @@ where
 // Consumer (the heapless `pkcs1v15` / `pss` sign-with-rng port) lands
 // in a later PR.
 #[allow(dead_code)]
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub fn rsa_private_op_and_check_blinded<R, T, M>(
     rng: &mut R,
     c: &T,
@@ -504,7 +500,7 @@ where
 /// The following (deterministic) algorithm also recovers the prime factors `p` and `q` of a modulus `n`, given the
 /// public exponent `e` and private exponent `d` using the method described in
 /// [NIST 800-56B Appendix C.2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br2.pdf).
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub fn recover_primes(
     n: &CryptoNonZero<BoxedUint>,
     e: &BoxedUint,
@@ -573,7 +569,7 @@ pub fn recover_primes(
 }
 
 /// Compute the modulus of a key from its primes.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub(crate) fn compute_modulus(primes: &[BoxedUint]) -> CryptoOdd<BoxedUint> {
     let mut primes = primes.iter();
     let mut out = primes.next().expect("must at least be one prime").clone();
@@ -585,7 +581,7 @@ pub(crate) fn compute_modulus(primes: &[BoxedUint]) -> CryptoOdd<BoxedUint> {
 
 /// Compute the private exponent from its primes (p and q) and public exponent
 /// This uses Euler's totient function
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn compute_private_exponent_euler_totient(
     primes: &[BoxedUint],
@@ -619,7 +615,7 @@ pub(crate) fn compute_private_exponent_euler_totient(
 ///
 /// FIPS 186-4 **requires** the private exponent to be less than λ(n), which would
 /// make Euler's totiem unreliable.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn compute_private_exponent_carmicheal(
     p: &BoxedUint,
@@ -646,7 +642,7 @@ pub(crate) fn compute_private_exponent_carmicheal(
 }
 
 #[cfg(test)]
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
 

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -12,5 +12,5 @@
 //! received extensive peer review by cryptographers.
 
 pub use crate::algorithms::rsa::rsa_encrypt;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub use crate::algorithms::rsa::{rsa_decrypt, rsa_decrypt_and_check};

--- a/src/key.rs
+++ b/src/key.rs
@@ -23,19 +23,18 @@ use {
     spki::{DecodePublicKey, EncodePublicKey},
 };
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "keygen")]
 use crate::algorithms::generate::generate_multi_prime_key_with_exp;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::algorithms::rsa::{
     compute_modulus, compute_private_exponent_carmicheal, compute_private_exponent_euler_totient,
     recover_primes,
 };
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
 use crate::traits::keys::PublicKeyParts;
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 use crate::traits::keys::{PrivateKeyParts, RawPrivateKeyConstructible};
 use crate::traits::{
     modular::ModulusParams, NonZero, PaddingScheme, SignatureScheme, UnsignedModularInt,
@@ -101,7 +100,6 @@ where
 /// Holds the public components plus the secret exponent `d`. The raw
 /// `(n, e, d)` form: `primes`, `precomputed` CRT values, and keygen are
 /// alloc-gated and absent on the heapless path.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub struct GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -116,15 +114,15 @@ where
     #[cfg(feature = "alloc")]
     pub(crate) primes: alloc::vec::Vec<T>,
     /// Precomputed CRT values, when available; `None` on the raw path.
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     pub(crate) precomputed: Option<PrecomputedValues<T, M>>,
 }
 
 // Manual `Clone`: the `M::MontgomeryForm: Clone` bound is only needed
-// when the `precomputed` field exists (private-key on). Keep it off the
-// wip-private-key variant so backends without a `Clone` MontgomeryForm
+// when the `precomputed` field exists (alloc on). Keep it off the
+// no-alloc variant so backends without a `Clone` MontgomeryForm
 // still build.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl<T, M> Clone for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize + Clone,
@@ -141,7 +139,7 @@ where
     }
 }
 
-#[cfg(all(feature = "wip-private-key", not(feature = "private-key")))]
+#[cfg(not(feature = "alloc"))]
 impl<T, M> Clone for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize + Clone,
@@ -158,7 +156,6 @@ where
 }
 
 // Manual `Debug` — never print `d`, so `{:?}` can't leak private material.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> fmt::Debug for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -178,7 +175,6 @@ where
 // unreachable on the `RsaPrivateKey` alias. Alloc callers must use the
 // validated `from_components` / `from_p_q` / `from_primes` paths so empty
 // `primes` can't leak into CRT-aware APIs as a `primes[0]` panic.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize + RawPrivateKeyConstructible,
@@ -194,13 +190,12 @@ where
             d,
             #[cfg(feature = "alloc")]
             primes: alloc::vec::Vec::new(),
-            #[cfg(feature = "private-key")]
+            #[cfg(feature = "alloc")]
             precomputed: None,
         }
     }
 }
 
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -212,7 +207,6 @@ where
     }
 }
 
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> PublicKeyParts<T> for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -233,7 +227,6 @@ where
     }
 }
 
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> PrivateKeyParts<T> for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -244,32 +237,32 @@ where
     }
 
     // Gate matches the `primes` field (`cfg(alloc)`).
-    #[cfg(all(feature = "private-key", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn primes(&self) -> &[T] {
         &self.primes
     }
 
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn dp(&self) -> Option<&T> {
         self.precomputed.as_ref().map(|p| &p.dp)
     }
 
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn dq(&self) -> Option<&T> {
         self.precomputed.as_ref().map(|p| &p.dq)
     }
 
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn qinv(&self) -> Option<&<Self::MontyParams as ModulusParams>::MontgomeryForm> {
         self.precomputed.as_ref().map(|p| &p.qinv)
     }
 
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn p_params(&self) -> Option<&Self::MontyParams> {
         self.precomputed.as_ref().map(|p| &p.p_params)
     }
 
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn q_params(&self) -> Option<&Self::MontyParams> {
         self.precomputed.as_ref().map(|p| &p.q_params)
     }
@@ -277,7 +270,6 @@ where
 
 // `Zeroize` on the type; `Drop` delegates so the wipe lives in one place.
 // Only `d` (and CRT precompute) is secret — the pubkey is public.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> Zeroize for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -287,12 +279,11 @@ where
         self.d.zeroize();
         #[cfg(feature = "alloc")]
         self.primes.zeroize();
-        #[cfg(feature = "private-key")]
+        #[cfg(feature = "alloc")]
         self.precomputed.zeroize();
     }
 }
 
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> Drop for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -303,7 +294,6 @@ where
     }
 }
 
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 impl<T, M> ZeroizeOnDrop for GenericRsaPrivateKey<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -323,15 +313,15 @@ where
 ///     let _: RsaPrivateKey = RsaPrivateKey::from_public_and_d(pub_key, d);
 /// }
 /// ```
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub type RsaPrivateKey = GenericRsaPrivateKey<BoxedUint, BoxedMontyParams>;
 
 // `Debug`, `Drop`, `ZeroizeOnDrop`, `PublicKeyParts` come from the generic
 // impls above via the alias.
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl Eq for RsaPrivateKey {}
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl PartialEq for RsaPrivateKey {
     #[inline]
     fn eq(&self, other: &RsaPrivateKey) -> bool {
@@ -341,14 +331,14 @@ impl PartialEq for RsaPrivateKey {
     }
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl AsRef<RsaPublicKey> for RsaPrivateKey {
     fn as_ref(&self) -> &RsaPublicKey {
         &self.pubkey_components
     }
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl Hash for RsaPrivateKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Domain separator for RSA private keys
@@ -357,7 +347,7 @@ impl Hash for RsaPrivateKey {
     }
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub(crate) struct PrecomputedValues<T, M>
 where
     T: UnsignedModularInt,
@@ -378,7 +368,7 @@ where
 
 // Manual `Clone` — `#[derive]` wouldn't add the `M::MontgomeryForm: Clone`
 // bound, only `T: Clone` / `M: Clone`.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl<T, M> Clone for PrecomputedValues<T, M>
 where
     T: UnsignedModularInt + Clone,
@@ -396,7 +386,7 @@ where
     }
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl<T, M> ZeroizeOnDrop for PrecomputedValues<T, M>
 where
     T: UnsignedModularInt,
@@ -404,7 +394,7 @@ where
 {
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl<T, M> Zeroize for PrecomputedValues<T, M>
 where
     T: UnsignedModularInt + Zeroize,
@@ -425,7 +415,7 @@ where
 // Drop-check requires the bounds match the struct exactly. `T:
 // UnsignedModularInt` already implies `Zeroize` (via `FixedWidthUnsignedInt`),
 // so `self.zeroize()` resolves here.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl<T, M> Drop for PrecomputedValues<T, M>
 where
     T: UnsignedModularInt,
@@ -436,14 +426,14 @@ where
     }
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl From<RsaPrivateKey> for GenericRsaPublicKey<BoxedUint, BoxedMontyParams> {
     fn from(private_key: RsaPrivateKey) -> Self {
         (&private_key).into()
     }
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl From<&RsaPrivateKey> for GenericRsaPublicKey<BoxedUint, BoxedMontyParams> {
     fn from(private_key: &RsaPrivateKey) -> Self {
         let public_key: &dyn PublicKeyParts<BoxedUint, MontyParams = BoxedMontyParams> =
@@ -583,7 +573,7 @@ impl GenericRsaPublicKey<BoxedUint, BoxedMontyParams> {
     }
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     /// Default exponent for RSA keys.
     const EXP: u64 = 65537;
@@ -595,6 +585,7 @@ impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     ///
     /// # Errors
     /// - If `bit_size` is lower than the minimum 1024-bits.
+    #[cfg(feature = "keygen")]
     pub fn new<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         Self::new_with_exp(rng, bit_size, Self::EXP.into())
     }
@@ -604,7 +595,7 @@ impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     /// #⚠️Warning: Hazmat!
     /// This version does not apply minimum key size checks, and as such may generate keys
     /// which are insecure!
-    #[cfg(feature = "hazmat")]
+    #[cfg(all(feature = "hazmat", feature = "keygen"))]
     pub fn new_unchecked<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         Self::new_with_exp_unchecked(rng, bit_size, Self::EXP.into())
     }
@@ -613,6 +604,7 @@ impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     /// using the passed in `rng`.
     ///
     /// Unless you have specific needs, you should use [`RsaPrivateKey::new`] instead.
+    #[cfg(feature = "keygen")]
     pub fn new_with_exp<R: CryptoRng + ?Sized>(
         rng: &mut R,
         bit_size: usize,
@@ -639,7 +631,7 @@ impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     /// #⚠️Warning: Hazmat!
     /// This version does not apply minimum key size checks, and as such may generate keys
     /// which are insecure!
-    #[cfg(feature = "hazmat")]
+    #[cfg(all(feature = "hazmat", feature = "keygen"))]
     pub fn new_with_exp_unchecked<R: CryptoRng + ?Sized>(
         rng: &mut R,
         bit_size: usize,
@@ -746,7 +738,7 @@ impl GenericRsaPrivateKey<BoxedUint, BoxedMontyParams> {
     /// This is intended for interoperating with systems that use non-standard exponents
     /// or loading legacy keys. Use [`RsaPrivateKey::from_components`] for standard key
     /// construction.
-    #[cfg(all(feature = "hazmat", feature = "private-key"))]
+    #[cfg(all(feature = "hazmat", feature = "alloc"))]
     pub fn from_components_with_large_exponent(
         n: BoxedUint,
         e: BoxedUint,
@@ -1037,7 +1029,7 @@ fn check_public_skip_exponent_size(n: &BoxedUint, e: &BoxedUint) -> Result<()> {
 ///
 /// This performs the structural and mathematical validation checks that are common to both
 /// `validate()` and `validate_skip_exponent_size()`.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 fn validate_private_key_parts(key: &RsaPrivateKey) -> Result<()> {
     // Check that Πprimes == n.
     let mut m = BoxedUint::one_with_precision(key.pubkey_components.n.bits_precision());
@@ -1076,7 +1068,7 @@ fn validate_private_key_parts(key: &RsaPrivateKey) -> Result<()> {
 ///
 /// This performs all the same checks as `RsaPrivateKey::validate()` except
 /// it doesn't verify that the exponent is within the standard bounds.
-#[cfg(all(feature = "hazmat", feature = "private-key"))]
+#[cfg(all(feature = "hazmat", feature = "alloc"))]
 fn validate_skip_exponent_size(key: &RsaPrivateKey) -> Result<()> {
     // Check public key properties (without exponent size checks)
     check_public_skip_exponent_size(key.pubkey_components.n.as_ref(), &key.pubkey_components.e)?;
@@ -1132,7 +1124,7 @@ impl<'de> Deserialize<'de> for RsaPrivateKey {
 }
 
 #[cfg(test)]
-#[cfg(all(feature = "alloc", feature = "private-key"))]
+#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
     use crate::algorithms::rsa::{rsa_decrypt_and_check, rsa_encrypt};
@@ -1191,7 +1183,7 @@ mod tests {
 
     macro_rules! key_generation {
         ($name:ident, $multi:expr, $size:expr) => {
-            #[cfg(feature = "private-key")]
+            #[cfg(feature = "keygen")]
             #[test]
             fn $name() {
                 let mut rng = ChaCha8Rng::from_seed([42; 32]);
@@ -1212,11 +1204,6 @@ mod tests {
 
                     test_key_basics(&private_key);
                 }
-            }
-            #[cfg(not(feature = "private-key"))]
-            #[test]
-            fn $name() {
-                todo!("generate_multi_prime_key_with_exp is not implemented yet");
             }
         };
     }
@@ -1264,7 +1251,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use rand::rngs::ChaCha8Rng;
         use rand_core::SeedableRng;
@@ -1505,7 +1492,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "hazmat")]
+    #[cfg(all(feature = "hazmat", feature = "keygen"))]
     fn test_from_components_with_large_exponent() {
         // Test that from_components_with_large_exponent accepts exponents outside normal bounds
         // while from_components would reject them
@@ -1553,7 +1540,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "hazmat")]
+    #[cfg(all(feature = "hazmat", feature = "keygen"))]
     fn test_from_components_with_small_exponent() {
         // Test that from_components_with_large_exponent accepts exponents below normal minimum
         // (despite the name, it works for any non-standard exponent size)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(not(all(feature = "alloc", feature = "private-key")), allow(unused))]
+#![cfg_attr(not(all(feature = "alloc", feature = "keygen")), allow(unused))]
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs)]
@@ -52,8 +52,8 @@
 //! See security notes in the <code><a href="./pkcs1v15/index.html">pkcs1v15</a></code> module.
 //! </div>
 //!
-#![cfg_attr(feature = "private-key", doc = "```")]
-#![cfg_attr(not(feature = "private-key"), doc = "```ignore")]
+#![cfg_attr(feature = "keygen", doc = "```")]
+#![cfg_attr(not(feature = "keygen"), doc = "```ignore")]
 //! use rsa::{RsaPrivateKey, RsaPublicKey, Pkcs1v15Encrypt};
 //!
 //! let mut rng = rand::rng();
@@ -276,9 +276,8 @@ pub use crate::{
     pkcs1v15::{Pkcs1v15Encrypt, Pkcs1v15Sign},
 };
 
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub use crate::key::GenericRsaPrivateKey;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub use crate::key::RsaPrivateKey;
 
 #[cfg(feature = "alloc")]

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -268,10 +268,7 @@ where
 // construction. The heapless-build blanket on
 // `FixedWidthUnsignedInt + PartialOrd` doesn't reach `ModMathValue<T>`
 // (a newtype, not itself `FixedWidthUnsignedInt`), so impl it here.
-#[cfg(all(
-    feature = "alloc",
-    any(feature = "private-key", feature = "wip-private-key")
-))]
+#[cfg(feature = "alloc")]
 impl<T> crate::traits::keys::RawPrivateKeyConstructible for ModMathValue<T> where
     T: FixedWidthUnsignedInt + PartialOrd
 {
@@ -750,7 +747,7 @@ impl<T: ModMathIntCt + HasPersonality<P = Ct>> crate::traits::modular::CtModulus
 }
 
 #[cfg(test)]
-#[cfg(all(feature = "alloc", feature = "private-key"))]
+#[cfg(feature = "alloc")]
 mod tests {
     use const_num_traits::Ct;
     use fixed_bigint::FixedUInt;
@@ -932,11 +929,9 @@ mod tests {
 }
 
 // Tests for the `rsa_private_op` primitive on the heapless / Ct path.
-// Gated independently of the alloc+private-key block above so the
-// `wip-private-key` feature (which doesn't imply alloc) can compile
-// and run them in no_alloc mode.
+// Gated independently of the alloc block above so they compile and
+// run in no_alloc mode.
 #[cfg(test)]
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 mod private_op_tests {
     use super::*;
     use const_num_traits::Ct;
@@ -1048,8 +1043,8 @@ mod private_op_tests {
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
 
         // Stack-only sample buffer so this test compiles under
-        // `--no-default-features --features modmath,wip-private-key`
-        // (no `alloc`). Sixteen fixed-size samples.
+        // `--no-default-features --features modmath` (no `alloc`).
+        // Sixteen fixed-size samples.
         let mut samples = [ModMathValue::<SmallUCt>::from(0u8); 16];
         for slot in samples.iter_mut() {
             let r = ModMathValue::<SmallUCt>::try_random_mod(&mut rng, &n).unwrap();
@@ -1143,8 +1138,7 @@ mod private_op_tests {
 
     // 2048-bit RSA keypair fixture — same `(n, e=65537, d)` used in
     // `algorithms::rsa::tests::recover_primes_works`. Pulled in here so the
-    // heapless wip-private-key test path can roundtrip-sign without
-    // requiring `alloc`. `e` is rendered as 3-byte BE (`0x010001`) and
+    // heapless test path can roundtrip-sign without requiring `alloc`. `e` is rendered as 3-byte BE (`0x010001`) and
     // resized into `U2048` at test time.
     const N_2048: [u8; 256] = hex_literal::hex!(
         "d397b84d98a4c26138ed1b695a8106ead91d553bf06041b62d3fdc50a041e222

--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -4,13 +4,13 @@
 //!
 //! See [code example in the toplevel rustdoc](../index.html#oaep-encryption).
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 mod decrypting_key;
 mod encrypting_key;
 #[cfg(not(feature = "alloc"))]
 mod label;
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub use self::decrypting_key::DecryptingKey;
 #[cfg(feature = "alloc")]
 pub use self::encrypting_key::EncryptingKey;
@@ -32,12 +32,12 @@ use rand_core::TryCryptoRng;
 use crate::algorithms::oaep::*;
 #[cfg(feature = "alloc")]
 use crate::algorithms::pad::{uint_to_be_pad, uint_to_be_pad_into, uint_to_zeroizing_be_pad};
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::algorithms::rsa::rsa_decrypt_and_check;
 #[cfg(feature = "alloc")]
 use crate::algorithms::rsa::rsa_encrypt;
 use crate::errors::{Error, Result};
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::key::RsaPrivateKey;
 #[cfg(feature = "alloc")]
 use crate::key::{self, RsaPublicKey};
@@ -170,7 +170,7 @@ where
     D: Digest + FixedOutputReset,
     MGD: Digest + FixedOutputReset,
 {
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn decrypt<Rng: TryCryptoRng + ?Sized>(
         mut self,
         rng: Option<&mut Rng>,
@@ -320,7 +320,7 @@ where
 /// See `decrypt_session_key` for a way of solving this problem.
 ///
 /// [PKCS#1 OAEP]: https://datatracker.ietf.org/doc/html/rfc8017#section-7.1
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 fn decrypt<R, D, MGD>(
     rng: Option<&mut R>,
@@ -359,7 +359,7 @@ where
 /// See `decrypt_session_key` for a way of solving this problem.
 ///
 /// [PKCS#1 OAEP]: https://datatracker.ietf.org/doc/html/rfc8017#section-7.1
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 fn decrypt_digest<R, D, MGD>(
     rng: Option<&mut R>,
@@ -386,7 +386,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg(all(feature = "alloc", feature = "private-key"))]
+#[cfg(feature = "alloc")]
 mod tests {
     use crate::key::{RsaPrivateKey, RsaPublicKey};
     use crate::oaep::{DecryptingKey, EncryptingKey, Oaep};

--- a/src/oaep/decrypting_key.rs
+++ b/src/oaep/decrypting_key.rs
@@ -98,7 +98,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use rand::rngs::ChaCha8Rng;

--- a/src/oaep/encrypting_key.rs
+++ b/src/oaep/encrypting_key.rs
@@ -125,7 +125,7 @@ where
 mod tests {
 
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde", feature = "private-key"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use rand::rngs::ChaCha8Rng;

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -26,19 +26,17 @@
 //!
 //! [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 mod decrypting_key;
 mod encrypting_key;
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 mod generic_signing_key;
 mod signature;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 mod signing_key;
 mod verifying_key;
 
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub use self::generic_signing_key::GenericSigningKey;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub use self::{
     decrypting_key::DecryptingKey,
     encrypting_key::GenericEncryptingKey,
@@ -46,7 +44,7 @@ pub use self::{
     signing_key::SigningKey,
     verifying_key::GenericVerifyingKey,
 };
-#[cfg(not(feature = "private-key"))]
+#[cfg(not(feature = "alloc"))]
 pub use self::{
     encrypting_key::GenericEncryptingKey,
     signature::{GenericSignature, SignatureBytes},
@@ -69,12 +67,12 @@ use crate::algorithms::pad::uint_to_be_pad_into;
 #[cfg(feature = "alloc")]
 use crate::algorithms::pad::uint_to_zeroizing_be_pad;
 use crate::algorithms::pkcs1v15::*;
-#[cfg(not(feature = "private-key"))]
+#[cfg(not(feature = "alloc"))]
 use crate::algorithms::rsa::rsa_encrypt;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::algorithms::rsa::{rsa_decrypt_and_check, rsa_encrypt};
 use crate::errors::{Error, Result};
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::key::{self, RsaPrivateKey};
 use crate::traits::{PaddingScheme, PublicKeyParts, SignatureScheme, UnsignedModularInt};
 
@@ -171,7 +169,7 @@ where
 }
 
 impl PaddingScheme for Pkcs1v15Encrypt {
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn decrypt<Rng: TryCryptoRng + ?Sized>(
         self,
         rng: Option<&mut Rng>,
@@ -241,7 +239,7 @@ impl Pkcs1v15Sign {
 }
 
 impl SignatureScheme for Pkcs1v15Sign {
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn sign<Rng: TryCryptoRng + ?Sized>(
         self,
         rng: Option<&mut Rng>,
@@ -312,7 +310,7 @@ where
 /// learn whether each instance returned an error then they can decrypt and
 /// forge signatures as if they had the private key. See
 /// `decrypt_session_key` for a way of solving this problem.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 fn decrypt<R: TryCryptoRng + ?Sized>(
     rng: Option<&mut R>,
@@ -341,7 +339,7 @@ fn decrypt<R: TryCryptoRng + ?Sized>(
 /// messages is small, an attacker may be able to build a map from
 /// messages to signatures and identify the signed messages. As ever,
 /// signatures provide authenticity, not confidentiality.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 #[inline]
 fn sign<R: TryCryptoRng + ?Sized>(
     rng: Option<&mut R>,
@@ -421,7 +419,7 @@ mod oid {
 pub use oid::RsaSignatureAssociatedOid;
 
 #[cfg(test)]
-#[cfg(all(feature = "alloc", feature = "private-key"))]
+#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
     use ::signature::{

--- a/src/pkcs1v15/decrypting_key.rs
+++ b/src/pkcs1v15/decrypting_key.rs
@@ -57,7 +57,7 @@ impl ZeroizeOnDrop for DecryptingKey {}
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use rand::rngs::ChaCha8Rng;

--- a/src/pkcs1v15/encrypting_key.rs
+++ b/src/pkcs1v15/encrypting_key.rs
@@ -75,7 +75,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use crate::RsaPrivateKey;

--- a/src/pkcs1v15/generic_signing_key.rs
+++ b/src/pkcs1v15/generic_signing_key.rs
@@ -2,7 +2,7 @@
 //! `T` (integer), and `M` (Montgomery parameters), mirrors the shape of
 //! [`super::GenericVerifyingKey`] on the verify side.
 //!
-//! Compatible with the no_alloc / `wip-private-key` build path —
+//! Compatible with the no_alloc build path —
 //! [`GenericRsaPrivateKey<T, M>`] storage, fixed-size [`Prefix`] for
 //! the DigestInfo prefix, caller-supplied scratch buffers for the EM
 //! and signature output.
@@ -66,7 +66,7 @@ where
 // the `M::MontgomeryForm: Clone` bound on heapless backends where it
 // isn't needed (only `GenericRsaPrivateKey`'s `precomputed` field
 // requires it, and that field is `cfg(private-key)`).
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl<D, T, M> Clone for GenericSigningKey<D, T, M>
 where
     D: Digest,
@@ -83,7 +83,7 @@ where
     }
 }
 
-#[cfg(not(feature = "private-key"))]
+#[cfg(not(feature = "alloc"))]
 impl<D, T, M> Clone for GenericSigningKey<D, T, M>
 where
     D: Digest,

--- a/src/pkcs1v15/signing_key.rs
+++ b/src/pkcs1v15/signing_key.rs
@@ -35,6 +35,7 @@ where
     D: Digest + AssociatedOid,
 {
     /// Generate a new signing key with a prefix for the digest `D`.
+    #[cfg(feature = "keygen")]
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         Ok(Self::new(RsaPrivateKey::new(rng, bit_size)?))
     }
@@ -45,6 +46,7 @@ where
     D: Digest,
 {
     /// Generate a new signing key with an empty prefix.
+    #[cfg(feature = "keygen")]
     pub fn random_unprefixed<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         Ok(Self::new_unprefixed(RsaPrivateKey::new(rng, bit_size)?))
     }
@@ -286,7 +288,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use rand::rngs::ChaCha8Rng;

--- a/src/pkcs1v15/verifying_key.rs
+++ b/src/pkcs1v15/verifying_key.rs
@@ -308,7 +308,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use crate::RsaPrivateKey;

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -9,18 +9,16 @@
 //! [Probabilistic Signature Scheme]: https://en.wikipedia.org/wiki/Probabilistic_signature_scheme
 //! [RFC8017 § 8.1]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.1
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 mod blinded_signing_key;
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 mod generic_signing_key;
 mod signature;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 mod signing_key;
 mod verifying_key;
 
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub use self::generic_signing_key::GenericSigningKey;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub use self::{blinded_signing_key::BlindedSigningKey, signing_key::SigningKey};
 
 #[cfg(feature = "alloc")]
@@ -42,13 +40,13 @@ use rand_core::TryCryptoRng;
 #[cfg(feature = "alloc")]
 use crate::algorithms::pad::{uint_to_be_pad, uint_to_be_pad_into, uint_to_zeroizing_be_pad};
 use crate::algorithms::pss::*;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::algorithms::rsa::rsa_decrypt_and_check;
 #[cfg(feature = "alloc")]
 use crate::algorithms::rsa::rsa_encrypt;
 use crate::errors::{Error, Result};
 use crate::traits::{PublicKeyParts, SignatureScheme, UnsignedModularInt};
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::RsaPrivateKey;
 #[cfg(feature = "alloc")]
 use crate::RsaPublicKey;
@@ -124,7 +122,7 @@ impl<D> SignatureScheme for Pss<D>
 where
     D: Digest + FixedOutputReset,
 {
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn sign<Rng: TryCryptoRng + ?Sized>(
         mut self,
         rng: Option<&mut Rng>,
@@ -253,7 +251,7 @@ where
 /// Note that hashed must be the result of hashing the input message using the
 /// given hash function. The opts argument may be nil, in which case sensible
 /// defaults are used.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub(crate) fn sign<T, D>(
     rng: &mut T,
     blind: bool,
@@ -272,7 +270,7 @@ where
     sign_pss_with_salt(blind.then_some(rng), priv_key, hashed, &salt, digest)
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 pub(crate) fn sign_digest<T, D>(
     rng: &mut T,
     blind: bool,
@@ -295,7 +293,7 @@ where
 /// Note that hashed must be the result of hashing the input message using the
 /// given hash function. salt is a random sequence of bytes whose length will be
 /// later used to verify the signature.
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 fn sign_pss_with_salt<T, D>(
     blind_rng: Option<&mut T>,
     priv_key: &RsaPrivateKey,
@@ -316,7 +314,7 @@ where
     uint_to_zeroizing_be_pad(raw, priv_key.size())
 }
 
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 fn sign_pss_with_salt_digest<T, D>(
     blind_rng: Option<&mut T>,
     priv_key: &RsaPrivateKey,
@@ -691,6 +689,7 @@ tAboUGBxTDq3ZroNism3DaMIbKPyYrAqhKov1h5V
     }
 
     #[test]
+    #[cfg(feature = "keygen")]
     // Tests the corner case where the key is multiple of 8 + 1 bits long
     fn test_sign_and_verify_2049bit_key() {
         let plaintext = "Hello\n";

--- a/src/pss/blinded_signing_key.rs
+++ b/src/pss/blinded_signing_key.rs
@@ -51,12 +51,14 @@ where
     /// Create a new random RSASSA-PSS signing key which produces "blinded"
     /// signatures.
     /// Digest output size is used as a salt length.
+    #[cfg(feature = "keygen")]
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
         SigningKey::random(rng, bit_size).map(Self)
     }
 
     /// Create a new random RSASSA-PSS signing key which produces "blinded"
     /// signatures with a salt of the given length.
+    #[cfg(feature = "keygen")]
     pub fn random_with_salt_len<R: CryptoRng + ?Sized>(
         rng: &mut R,
         bit_size: usize,
@@ -279,7 +281,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use rand::rngs::ChaCha8Rng;

--- a/src/pss/generic_signing_key.rs
+++ b/src/pss/generic_signing_key.rs
@@ -64,7 +64,7 @@ where
 // the `M::MontgomeryForm: Clone` bound on heapless backends where it
 // isn't needed (only `GenericRsaPrivateKey`'s `precomputed` field
 // requires it, and that field is `cfg(private-key)`).
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 impl<D, T, M> Clone for GenericSigningKey<D, T, M>
 where
     D: Digest,
@@ -81,7 +81,7 @@ where
     }
 }
 
-#[cfg(not(feature = "private-key"))]
+#[cfg(not(feature = "alloc"))]
 impl<D, T, M> Clone for GenericSigningKey<D, T, M>
 where
     D: Digest,

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -39,6 +39,7 @@ use {
 /// [RFC8017 § 8.1]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.1
 pub type SigningKey<D> = GenericSigningKey<D, BoxedUint, BoxedMontyParams>;
 
+#[cfg(feature = "keygen")]
 impl<D> GenericSigningKey<D, BoxedUint, BoxedMontyParams>
 where
     D: Digest,
@@ -284,7 +285,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use rand::rngs::ChaCha8Rng;

--- a/src/pss/verifying_key.rs
+++ b/src/pss/verifying_key.rs
@@ -290,7 +290,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "hazmat", feature = "serde", feature = "private-key"))]
+    #[cfg(all(feature = "hazmat", feature = "serde", feature = "keygen"))]
     fn test_serde() {
         use super::*;
         use crate::RsaPrivateKey;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,7 +6,6 @@ pub(crate) mod modular;
 mod padding;
 
 pub use encryption::{Decryptor, EncryptingKeypair, RandomizedDecryptor, RandomizedEncryptor};
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub use keys::PrivateKeyParts;
 pub use keys::PublicKeyParts;
 pub use modular::{FixedWidthUnsignedInt, IntegerResize, NonZero, Odd, UnsignedModularInt};

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -13,16 +13,12 @@ use crate::traits::{modular::ModulusParams, NonZero, UnsignedModularInt};
 /// **Not impl'd for [`BoxedUint`]**: alloc callers must use the validated
 /// `RsaPrivateKey::from_components` / `from_p_q` / `from_primes` paths, so
 /// empty `primes` can't leak into CRT-aware APIs as a `primes[0]` panic.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub trait RawPrivateKeyConstructible: UnsignedModularInt {}
 
 // Heapless build: `FixedWidthUnsignedInt + PartialOrd` matches the
 // `UnsignedModularInt` blanket and gets the marker for free. `BoxedUint`
 // isn't `Copy`, so it can't satisfy `FixedWidthUnsignedInt`.
-#[cfg(all(
-    any(feature = "private-key", feature = "wip-private-key"),
-    not(feature = "alloc")
-))]
+#[cfg(not(feature = "alloc"))]
 impl<T> RawPrivateKeyConstructible for T where
     T: crate::traits::modular::FixedWidthUnsignedInt + PartialOrd
 {
@@ -73,7 +69,6 @@ pub trait PublicKeyParts<T: UnsignedModularInt> {
 /// `p_params`/`q_params`) are `private-key`-gated to the alloc path and
 /// default to `None`, so a key without CRT precompute satisfies the trait
 /// with just `d()`.
-#[cfg(any(feature = "private-key", feature = "wip-private-key"))]
 pub trait PrivateKeyParts<T>: PublicKeyParts<T>
 where
     T: UnsignedModularInt,
@@ -83,38 +78,38 @@ where
 
     /// Returns the prime factors of the modulus. Returns `&[]` for keys
     /// that don't store factors (the heapless default).
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn primes(&self) -> &[T] {
         &[]
     }
 
     /// Returns the precomputed `dp = d mod (p - 1)` value, if available.
     /// `None` for keys that didn't precompute CRT (the heapless default).
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn dp(&self) -> Option<&T> {
         None
     }
 
     /// Returns the precomputed `dq = d mod (q - 1)` value, if available.
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn dq(&self) -> Option<&T> {
         None
     }
 
     /// Returns the precomputed `qinv = q^-1 mod p` value, if available.
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn qinv(&self) -> Option<&<Self::MontyParams as ModulusParams>::MontgomeryForm> {
         None
     }
 
     /// Returns the Montgomery parameters for `p`, if available.
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn p_params(&self) -> Option<&Self::MontyParams> {
         None
     }
 
     /// Returns the Montgomery parameters for `q`, if available.
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn q_params(&self) -> Option<&Self::MontyParams> {
         None
     }

--- a/src/traits/padding.rs
+++ b/src/traits/padding.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use rand_core::TryCryptoRng;
 
 use crate::errors::Result;
-#[cfg(feature = "private-key")]
+#[cfg(feature = "alloc")]
 use crate::key::RsaPrivateKey;
 use crate::traits::modular::CtModulusParams;
 use crate::traits::{PublicKeyParts, UnsignedModularInt};
@@ -17,7 +17,7 @@ pub trait PaddingScheme {
     ///
     /// If an `rng` is passed, it uses RSA blinding to help mitigate timing
     /// side-channel attacks.
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn decrypt<Rng: TryCryptoRng + ?Sized>(
         self,
         rng: Option<&mut Rng>,
@@ -38,7 +38,7 @@ pub trait PaddingScheme {
 /// Digital signature scheme.
 pub trait SignatureScheme {
     /// Sign the given digest.
-    #[cfg(feature = "private-key")]
+    #[cfg(feature = "alloc")]
     fn sign<Rng: TryCryptoRng + ?Sized>(
         self,
         rng: Option<&mut Rng>,

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -1,6 +1,6 @@
 //! Property-based tests.
 
-#![cfg(all(feature = "hazmat", feature = "private-key"))]
+#![cfg(all(feature = "hazmat", feature = "keygen"))]
 
 use proptest::prelude::*;
 use rand::rngs::ChaCha8Rng;


### PR DESCRIPTION
## Summary

The `wip-private-key` marker gate graduates: the ported private-key surface (sign primitives, `GenericSigningKey` wrappers, blinding) is complete, so its items move to the base crate — generic code, usable on no-alloc builds with the modmath backend.

`private-key` retires with it. It was a fork invention (upstream has no such feature — everything private-key is unconditional there), and the "one big gate" no longer matches reality now that most of the surface works heapless. Its remainder splits:

- **`keygen` (new, in default features)** — `RsaPrivateKey::new` + friends, the `generate` module, `dep:crypto-primes`. Never available no-alloc: embedded keys come from a provisioning path (PEM/HSM/firmware constants), not on-device generation. Key-generating tests (`key_generation!`, `test_serde`, the 2049-bit PSS round trip) gate here.
- **`alloc`** — everything else BoxedUint-bound: decrypt, CRT precompute storage/accessors, `from_components`, the boxed wrappers. Type-gated on no-alloc anyway; the cfg now names the real requirement.

`default = ["std", "encoding", "modmath", "keygen"]` preserves today's default surface exactly.

Also swept along:
- `key_generation!` macro's `not(private-key)` `todo!()` fallback arm removed (previously dead code; started running — and panicking — under alloc-without-keygen).
- Stale `#[allow(dead_code)]` + "consumer lands in same PR" comments dropped from both `sign_with_rng_into` primitives.
- Stale `wip-private-key` comment references updated.
- README scope section rewritten: heapless signing exists (CT exponent + optional per-signature blinding); keygen and decrypt remain off the heapless path.

Feature removal is a breaking change; rides the major bump already required by the Phase 5 trait removal.

## Test plan
- [x] `cargo hack check --feature-powerset --exclude-features getrandom,serde --no-dev-deps` — all 76 combos
- [x] `cargo test --lib` (default), `--no-default-features --features "std encoding modmath sha2 hazmat serde"` (alloc-without-keygen), `--doc`, `--test pkcs1v15`
- [x] `cargo clippy --all -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)