### PR TITLE
Migrate to const-num-traits 0.2 stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,5 +116,5 @@ debug = true
 [patch.crates-io]
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1" }
 fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.3" }
-modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.2" }
-modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.2" }
+modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.3" }
+modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
-modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.3", optional = true, default-features = false, features = ["zeroize"] }
+modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.4", optional = true, default-features = false, features = ["zeroize"] }
 # Registry-only on purpose (matches modmath's own dep) — a git copy would
 # give `CiosRowOps` a second identity and split the trait universe.
 modmath-cios = { version = "0.1", optional = true, default-features = false }
@@ -64,7 +64,7 @@ serde_json = "1.0.138"
 serde = { version = "1.0.184", features = ["derive"] }
 rstest = "0.26.1"
 crypto-bigint = { version = "0.7", default-features = false, features = ["zeroize", "alloc"] }
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.3", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.4", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 
 [[bench]]
 name = "key"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,6 @@ debug = true
 # block when the stable line lands on crates.io.
 [patch.crates-io]
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1" }
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.1" }
-modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.1" }
-modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.1" }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.2" }
+modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.2" }
+modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,11 @@ rand_core = { version = "0.10", default-features = false }
 signature = { version = "3", default-features = false, features = ["digest", "rand_core"] }
 zeroize = { version = "1.8", default-features = false }
 ctutils = { version = "0.4", default-features = false }
-const-num-traits = { version = "0.2.0", default-features = false, features = ["ct"] }
+# Direct git deps — not `[patch.crates-io]` — so downstream consumers of
+# this alpha line get the tags transitively (a dependency's patch table is
+# ignored by consumers). Same convention as the fixed-bigint / modmath
+# alphas. Revert to plain crates.io versions when the stable line ships.
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 
 # optional dependencies
 crypto-common = { version = "0.2", optional = true, features = ["getrandom"] }
@@ -38,8 +42,10 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
-modmath = { version = "0.5.0", optional = true, default-features = false, features = ["zeroize"] }
-modmath-cios = { version = "0.1.1", optional = true, default-features = false }
+modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.3", optional = true, default-features = false, features = ["zeroize"] }
+# Registry-only on purpose (matches modmath's own dep) — a git copy would
+# give `CiosRowOps` a second identity and split the trait universe.
+modmath-cios = { version = "0.1", optional = true, default-features = false }
 subtle = { version = "2.6", default-features = false }
 heapless = "0.9"
 
@@ -58,7 +64,7 @@ serde_json = "1.0.138"
 serde = { version = "1.0.184", features = ["derive"] }
 rstest = "0.26.1"
 crypto-bigint = { version = "0.7", default-features = false, features = ["zeroize", "alloc"] }
-fixed-bigint = { version = "0.5.0", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.3", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 
 [[bench]]
 name = "key"
@@ -107,14 +113,3 @@ opt-level = 2
 
 [profile.bench]
 debug = true
-
-# Temporary — next-generation alpha stack: const-num-traits 0.2 (explicit
-# wrapping-op contracts, `ct` feature), fixed-bigint 0.5, modmath 0.5.
-# fixed-bigint/modmath alphas carry direct git deps on the same
-# const-num-traits tag, so all three must move in lockstep. Drop this
-# block when the stable line lands on crates.io.
-[patch.crates-io]
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1" }
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.3" }
-modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.3" }
-modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand_core = { version = "0.10", default-features = false }
 signature = { version = "3", default-features = false, features = ["digest", "rand_core"] }
 zeroize = { version = "1.8", default-features = false }
 ctutils = { version = "0.4", default-features = false }
-const-num-traits = { version = "0.1.2", default-features = false }
+const-num-traits = { version = "0.2.0", default-features = false, features = ["ct"] }
 
 # optional dependencies
 crypto-common = { version = "0.2", optional = true, features = ["getrandom"] }
@@ -38,8 +38,8 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
-modmath = { version = "0.4.1", optional = true, default-features = false, features = ["zeroize"] }
-modmath-cios = { version = "0.1.0", optional = true, default-features = false }
+modmath = { version = "0.5.0", optional = true, default-features = false, features = ["zeroize"] }
+modmath-cios = { version = "0.1.1", optional = true, default-features = false }
 subtle = { version = "2.6", default-features = false }
 heapless = "0.9"
 
@@ -58,7 +58,7 @@ serde_json = "1.0.138"
 serde = { version = "1.0.184", features = ["derive"] }
 rstest = "0.26.1"
 crypto-bigint = { version = "0.7", default-features = false, features = ["zeroize", "alloc"] }
-fixed-bigint = { version = "0.4.1", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+fixed-bigint = { version = "0.5.0", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 
 [[bench]]
 name = "key"
@@ -107,3 +107,14 @@ opt-level = 2
 
 [profile.bench]
 debug = true
+
+# Temporary — next-generation alpha stack: const-num-traits 0.2 (explicit
+# wrapping-op contracts, `ct` feature), fixed-bigint 0.5, modmath 0.5.
+# fixed-bigint/modmath alphas carry direct git deps on the same
+# const-num-traits tag, so all three must move in lockstep. Drop this
+# block when the stable line lands on crates.io.
+[patch.crates-io]
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1" }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.1" }
+modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.1" }
+modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa_heapless"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>", "kaidokert@gmail.com"]
 edition = "2021"
 description = "Pure Rust RSA implementation - heapless fork"
@@ -24,11 +24,7 @@ rand_core = { version = "0.10", default-features = false }
 signature = { version = "3", default-features = false, features = ["digest", "rand_core"] }
 zeroize = { version = "1.8", default-features = false }
 ctutils = { version = "0.4", default-features = false }
-# Direct git deps — not `[patch.crates-io]` — so downstream consumers of
-# this alpha line get the tags transitively (a dependency's patch table is
-# ignored by consumers). Same convention as the fixed-bigint / modmath
-# alphas. Revert to plain crates.io versions when the stable line ships.
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
+const-num-traits = { version = "0.2.0", default-features = false, features = ["ct"] }
 
 # optional dependencies
 crypto-common = { version = "0.2", optional = true, features = ["getrandom"] }
@@ -42,10 +38,8 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 # Big integer backend
 crypto-bigint = { version = "0.7.1", optional = true, default-features = false, features = ["zeroize","rand_core"] }
-modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.4", optional = true, default-features = false, features = ["zeroize"] }
-# Registry-only on purpose (matches modmath's own dep) — a git copy would
-# give `CiosRowOps` a second identity and split the trait universe.
-modmath-cios = { version = "0.1", optional = true, default-features = false }
+modmath = { version = "0.5.0", optional = true, default-features = false, features = ["zeroize"] }
+modmath-cios = { version = "0.1.1", optional = true, default-features = false }
 subtle = { version = "2.6", default-features = false }
 heapless = "0.9"
 
@@ -64,7 +58,7 @@ serde_json = "1.0.138"
 serde = { version = "1.0.184", features = ["derive"] }
 rstest = "0.26.1"
 crypto-bigint = { version = "0.7", default-features = false, features = ["zeroize", "alloc"] }
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.4", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+fixed-bigint = { version = "0.5.0", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 
 [[bench]]
 name = "key"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,6 @@ debug = true
 # block when the stable line lands on crates.io.
 [patch.crates-io]
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1" }
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.2" }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.3" }
 modmath = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.2" }
 modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.5.0-alpha.2" }

--- a/footprint/avr/Cargo.toml
+++ b/footprint/avr/Cargo.toml
@@ -22,10 +22,7 @@ hash_sha256 = []
 
 [dependencies]
 avr-device = { version = "0.7", features = ["atmega2560", "rt"] }
-# Temporary git pin — must match the fixed-bigint tag rsa_heapless's alpha
-# line uses, or FixedUInt won't satisfy the const-num-traits 0.2 bounds.
-# Back to a crates.io version when the stable 0.5 line ships.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.4", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+fixed-bigint = { version = "0.5.0", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 rsa = { path = "../..", package = "rsa_heapless", default-features = false, features = ["modmath"] }
 sha1 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }

--- a/footprint/avr/Cargo.toml
+++ b/footprint/avr/Cargo.toml
@@ -22,7 +22,10 @@ hash_sha256 = []
 
 [dependencies]
 avr-device = { version = "0.7", features = ["atmega2560", "rt"] }
-fixed-bigint = { version = "0.4.1", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+# Temporary git pin — must match the fixed-bigint tag rsa_heapless's alpha
+# line uses, or FixedUInt won't satisfy the const-num-traits 0.2 bounds.
+# Back to a crates.io version when the stable 0.5 line ships.
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.4", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 rsa = { path = "../..", package = "rsa_heapless", default-features = false, features = ["modmath"] }
 sha1 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }

--- a/footprint/avr/run_suite.py
+++ b/footprint/avr/run_suite.py
@@ -221,9 +221,10 @@ def main():
     print("Approx time is measured by the demo harness timer and should be treated as a rough runtime proxy, not a precise benchmark.")
 
     if failures:
-        print(f"\nFailures (non-fatal — shown as `-` in table): {len(failures)}", file=sys.stderr)
+        print(f"\nFailures (shown as `-` in table): {len(failures)}", file=sys.stderr)
         for failure in failures:
             print(f"  {failure}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/footprint/cortex-m/Cargo.toml
+++ b/footprint/cortex-m/Cargo.toml
@@ -29,10 +29,7 @@ cortex-m-rt = "0.7"
 cortex-m-semihosting = "0.5"
 panic-semihosting = { version = "0.6", features = ["exit"] }
 
-# Temporary git pin — must match the fixed-bigint tag rsa_heapless's alpha
-# line uses, or FixedUInt won't satisfy the const-num-traits 0.2 bounds.
-# Back to a crates.io version when the stable 0.5 line ships.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.4", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+fixed-bigint = { version = "0.5.0", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 rsa = { path = "../..", package = "rsa_heapless", default-features = false, features = ["modmath"] }
 sha1 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }

--- a/footprint/cortex-m/Cargo.toml
+++ b/footprint/cortex-m/Cargo.toml
@@ -29,7 +29,10 @@ cortex-m-rt = "0.7"
 cortex-m-semihosting = "0.5"
 panic-semihosting = { version = "0.6", features = ["exit"] }
 
-fixed-bigint = { version = "0.4.1", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+# Temporary git pin — must match the fixed-bigint tag rsa_heapless's alpha
+# line uses, or FixedUInt won't satisfy the const-num-traits 0.2 bounds.
+# Back to a crates.io version when the stable 0.5 line ships.
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.4", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 rsa = { path = "../..", package = "rsa_heapless", default-features = false, features = ["modmath"] }
 sha1 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }

--- a/footprint/cortex-m/run_suite.py
+++ b/footprint/cortex-m/run_suite.py
@@ -221,9 +221,10 @@ def main():
     print("Approx cycles are derived from the demo harness counters and should be treated as a rough instruction-cost proxy, not a precise benchmark.")
 
     if failures:
-        print(f"\nFailures (non-fatal — shown as `-` in table): {len(failures)}", file=sys.stderr)
+        print(f"\nFailures (shown as `-` in table): {len(failures)}", file=sys.stderr)
         for f in failures:
             print(f"  {f}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/footprint/risc-v/Cargo.toml
+++ b/footprint/risc-v/Cargo.toml
@@ -26,10 +26,7 @@ hash_sha256 = []
 [dependencies]
 riscv-rt = "0.13"
 
-# Temporary git pin — must match the fixed-bigint tag rsa_heapless's alpha
-# line uses, or FixedUInt won't satisfy the const-num-traits 0.2 bounds.
-# Back to a crates.io version when the stable 0.5 line ships.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.4", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+fixed-bigint = { version = "0.5.0", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 rsa = { path = "../..", package = "rsa_heapless", default-features = false, features = ["modmath"] }
 sha1 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }

--- a/footprint/risc-v/Cargo.toml
+++ b/footprint/risc-v/Cargo.toml
@@ -26,7 +26,10 @@ hash_sha256 = []
 [dependencies]
 riscv-rt = "0.13"
 
-fixed-bigint = { version = "0.4.1", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+# Temporary git pin — must match the fixed-bigint tag rsa_heapless's alpha
+# line uses, or FixedUInt won't satisfy the const-num-traits 0.2 bounds.
+# Back to a crates.io version when the stable 0.5 line ships.
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.5.0-alpha.4", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
 rsa = { path = "../..", package = "rsa_heapless", default-features = false, features = ["modmath"] }
 sha1 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }

--- a/footprint/risc-v/run_suite.py
+++ b/footprint/risc-v/run_suite.py
@@ -215,9 +215,10 @@ def main():
     print("Approx cycles are derived from the demo harness counters and should be treated as a rough instruction-cost proxy, not a precise benchmark.")
 
     if failures:
-        print(f"\nFailures (non-fatal — shown as `-` in table): {len(failures)}", file=sys.stderr)
+        print(f"\nFailures (shown as `-` in table): {len(failures)}", file=sys.stderr)
         for f in failures:
             print(f"  {f}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -651,17 +651,8 @@ where
     T: ModMathIntCt
         + HasPersonality<P = Ct>
         + modmath_cios::CiosRowOps
-        + core::ops::Shl<usize, Output = T>
         + core::ops::BitOr<Output = T>,
-    <T as modmath_cios::CiosRowOps>::Word: Copy
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeEq
-        + const_num_traits::CtIsZero
-        + const_num_traits::CtParity
-        + const_num_traits::One
-        + const_num_traits::Zero
-        + core::ops::BitAnd<Output = <T as modmath_cios::CiosRowOps>::Word>
-        + core::ops::Shl<usize, Output = <T as modmath_cios::CiosRowOps>::Word>,
+    <T as modmath_cios::CiosRowOps>::Word: const_num_traits::CtParity,
 {
     fn invert_ct(&self) -> Option<Self> {
         let field = self.params.field();

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -33,15 +33,16 @@ pub trait ModMathInt:
     + One
     + Zero
     + Parity
-    + OverflowingAdd
+    + OverflowingAdd<Output = Self>
     + WideMul
     + CiosMontMul
-    + WrappingAdd
-    + WrappingMul
-    + WrappingSub
+    + WrappingAdd<Output = Self>
+    + WrappingMul<Output = Self>
+    + WrappingSub<Output = Self>
     + Shr<usize, Output = Self>
     + ShrAssign<usize>
     + core::ops::Add<Output = Self>
+    + core::ops::Sub<Output = Self>
     + core::ops::Mul<Output = Self>
     + HasPersonality
 {
@@ -55,15 +56,16 @@ impl<T> ModMathInt for T where
         + One
         + Zero
         + Parity
-        + OverflowingAdd
+        + OverflowingAdd<Output = Self>
         + WideMul
         + CiosMontMul
-        + WrappingAdd
-        + WrappingMul
-        + WrappingSub
+        + WrappingAdd<Output = Self>
+        + WrappingMul<Output = Self>
+        + WrappingSub<Output = Self>
         + Shr<usize, Output = Self>
         + ShrAssign<usize>
         + core::ops::Add<Output = Self>
+        + core::ops::Sub<Output = Self>
         + core::ops::Mul<Output = Self>
         + HasPersonality
 {
@@ -77,18 +79,19 @@ pub trait ModMathIntCt:
     + One
     + Zero
     + Parity
-    + OverflowingAdd
+    + OverflowingAdd<Output = Self>
     + WideMul
     + CiosMontMulCt
-    + WrappingAdd
-    + WrappingMul
-    + WrappingSub
+    + WrappingAdd<Output = Self>
+    + WrappingMul<Output = Self>
+    + WrappingSub<Output = Self>
     + Shr<usize, Output = Self>
     + ShrAssign<usize>
     + subtle::ConditionallySelectable
     + subtle::ConstantTimeLess
     + core::ops::BitAnd<Output = Self>
     + core::ops::Add<Output = Self>
+    + core::ops::Sub<Output = Self>
     + core::ops::Mul<Output = Self>
     + HasPersonality
     + const_num_traits::CtIsZero
@@ -103,18 +106,19 @@ impl<T> ModMathIntCt for T where
         + One
         + Zero
         + Parity
-        + OverflowingAdd
+        + OverflowingAdd<Output = Self>
         + WideMul
         + CiosMontMulCt
-        + WrappingAdd
-        + WrappingMul
-        + WrappingSub
+        + WrappingAdd<Output = Self>
+        + WrappingMul<Output = Self>
+        + WrappingSub<Output = Self>
         + Shr<usize, Output = Self>
         + ShrAssign<usize>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess
         + core::ops::BitAnd<Output = Self>
         + core::ops::Add<Output = Self>
+        + core::ops::Sub<Output = Self>
         + core::ops::Mul<Output = Self>
         + HasPersonality
         + const_num_traits::CtIsZero

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -41,9 +41,6 @@ pub trait ModMathInt:
     + WrappingSub<Output = Self>
     + Shr<usize, Output = Self>
     + ShrAssign<usize>
-    + core::ops::Add<Output = Self>
-    + core::ops::Sub<Output = Self>
-    + core::ops::Mul<Output = Self>
     + HasPersonality
 {
 }
@@ -64,9 +61,6 @@ impl<T> ModMathInt for T where
         + WrappingSub<Output = Self>
         + Shr<usize, Output = Self>
         + ShrAssign<usize>
-        + core::ops::Add<Output = Self>
-        + core::ops::Sub<Output = Self>
-        + core::ops::Mul<Output = Self>
         + HasPersonality
 {
 }
@@ -90,9 +84,6 @@ pub trait ModMathIntCt:
     + subtle::ConditionallySelectable
     + subtle::ConstantTimeLess
     + core::ops::BitAnd<Output = Self>
-    + core::ops::Add<Output = Self>
-    + core::ops::Sub<Output = Self>
-    + core::ops::Mul<Output = Self>
     + HasPersonality
     + const_num_traits::CtIsZero
 {
@@ -117,9 +108,6 @@ impl<T> ModMathIntCt for T where
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess
         + core::ops::BitAnd<Output = Self>
-        + core::ops::Add<Output = Self>
-        + core::ops::Sub<Output = Self>
-        + core::ops::Mul<Output = Self>
         + HasPersonality
         + const_num_traits::CtIsZero
 {


### PR DESCRIPTION
## Summary

Compatibility probe for the coordinated alpha releases, pinned via `[patch.crates-io]`:

- [const-num-traits v0.2.0-alpha.1](https://github.com/kaidokert/num-traits/releases/tag/v0.2.0-alpha.1) — `Wrapping*`/`Overflowing*` traits grew associated `Output` types; Ct personality is behind the new `ct` feature
- [fixed-bigint v0.5.0-alpha.1](https://github.com/kaidokert/fixed-bigint-rs/releases/tag/v0.5.0-alpha.1)
- [modmath v0.5.0-alpha.1](https://github.com/kaidokert/modmath-rs/releases/tag/v0.5.0-alpha.1) (+ modmath-cios 0.1.1 from the same tag)

The fixed-bigint and modmath alphas carry **direct git deps** on the same const-num-traits tag, so our direct dep moves in lockstep — verified exactly one `const-num-traits` copy in the graph.

**Code fallout** is confined to the `ModMathInt` / `ModMathIntCt` trait aliases in `src/modmath_support.rs`: the `Wrapping*`/`OverflowingAdd` bounds gain `<Output = Self>` projections, and `core::ops::Sub<Output = Self>` joins the list (modmath 0.5 hoists it to the `Field` impl block). No behavioral changes.

The `[patch.crates-io]` block is temporary — drop it (keeping the version bumps) when the stable line lands on crates.io.

## Test plan
- [x] `cargo hack check --feature-powerset --exclude-features getrandom,serde --no-dev-deps` — all combos
- [x] `cargo test --lib` (106), `--test pkcs1v15`, `--doc`, and the alloc-without-keygen config (94)
- [x] `cargo check --no-default-features --features modmath` (no-alloc path)
- [x] `cargo clippy --all -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)