### PR TITLE
Footprint harness: compact sha2 soft backend

### DIFF
--- a/footprint/avr/.cargo/config.toml
+++ b/footprint/avr/.cargo/config.toml
@@ -1,6 +1,8 @@
 [build]
 target = "avr-none"
-rustflags = ["-C", "target-cpu=atmega2560"]
+# sha2 0.11 selects its soft backend via rustc cfg, not a cargo feature;
+# compact keeps the size-measurement harness honest.
+rustflags = ["-C", "target-cpu=atmega2560", "--cfg", 'sha2_backend_soft="compact"']
 
 [unstable]
 build-std = ["core"]

--- a/footprint/cortex-m/.cargo/config.toml
+++ b/footprint/cortex-m/.cargo/config.toml
@@ -9,3 +9,7 @@ runner = "qemu-system-arm -cpu cortex-m4 -machine netduinoplus2 -nographic -semi
 
 [build]
 target = "thumbv6m-none-eabi"
+# sha2 0.11 selects its soft backend via rustc cfg, not a cargo feature.
+# Without this the default (speed-oriented) backend costs ~6.5 KB more
+# .text — the wrong tradeoff for a size-measurement harness.
+rustflags = ['--cfg', 'sha2_backend_soft="compact"']

--- a/footprint/risc-v/.cargo/config.toml
+++ b/footprint/risc-v/.cargo/config.toml
@@ -1,5 +1,9 @@
 [build]
 target = "riscv32imac-unknown-none-elf"
+# sha2 0.11 selects its soft backend via rustc cfg, not a cargo feature.
+# Without this the default (speed-oriented) backend costs ~6.5 KB more
+# .text — the wrong tradeoff for a size-measurement harness.
+rustflags = ['--cfg', 'sha2_backend_soft="compact"']
 
 [target.riscv32imac-unknown-none-elf]
 runner = "python3 qemu_wrapper.py"


### PR DESCRIPTION
## Summary

sha2 0.11 moved its compact soft backend from the `force-soft-compact` cargo feature to a **rustc cfg** (`sha2_backend_soft="compact"`, [RustCrypto/hashes#686](https://github.com/RustCrypto/hashes/pull/686)) — so since the 0.11 bump the footprint suites have been silently measuring the speed-oriented default backend. This sets the cfg in all three harness `.cargo/config.toml`s; the compact backend is the right tradeoff for a size-measurement harness.

Measured effect on the verify-minus-baseline `.text` deltas:

| Config | before | after |
|---|---|---|
| Cortex-M3, SHA-256 (all key sizes) | ~13.1 KiB | **~6.5 KiB** |
| RV32, 2048/SHA-256 | 21.7 KiB | **9.5 KiB** |

SHA-1 rows are unchanged — sha1 0.11 has backend cfgs but no compact soft variant.

Harness-only change (`-Z ub-checks=no` precedent: measurement config, not shipped code). The README resource table predates both this and the 0.4.0 stack and needs a refresh pass from a full suite run — follow-up.

## Test plan
- [x] cortex-m and risc-v suites run clean locally with the cfg (exit 0, all ACCEPT)
- [x] AVR builds locally; suite validated by CI (fail-fast active since #49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure footprint harnesses to use the compact SHA-2 soft backend for accurate size measurements.

Enhancements:
- Set rustc cfg to select the compact SHA-2 soft backend in AVR footprint harness builds.
- Set rustc cfg to select the compact SHA-2 soft backend in Cortex-M footprint harness builds.
- Set rustc cfg to select the compact SHA-2 soft backend in RISC-V footprint harness builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated embedded-platform build configurations to use a compact SHA-2 backend.
  * Improved consistency of code-size measurement across AVR, Cortex-M, and RISC-V targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->