### PR TITLE
CT verification: narrow ladder branch-freedom check

### DIFF
--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -18,10 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Cross-compile the fixture staticlib for every ISA the driver
-  # disassembles, and assert the fixture symbols survive LTO. The
-  # disassembly scan is a separate job.
-  fixtures-build:
+  # Cross-build the fixture staticlib per ISA, disassemble it, and
+  # assert the secret-exponent ladder carries only its reviewed public
+  # bit-width loop branch (per-target count) and no more. Narrow by
+  # design — the whole-operation CT gate is the taint (ctgrind) harness;
+  # this confirms the one property asm-grep can prove cheaply. The
+  # driver fails closed if the ladder symbol is absent (inlined/renamed)
+  # or if the negative controls stop tripping the mnemonic tables.
+  ladder-check:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -36,19 +40,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          # Pinned so codegen — and therefore the eventual asm-grep
-          # calibration — stays deterministic across CI runs.
+          # Pinned so codegen — and the calibrated per-ISA ladder branch
+          # counts — stay deterministic across CI runs.
           toolchain: 1.87.0
           targets: ${{ matrix.target }}
           components: llvm-tools-preview
-      - name: Cross-build fixtures
+      - name: Ladder branch-freedom check
         working-directory: ct-verify
-        run: cargo build -p ct-fixtures --release --target ${{ matrix.target }}
-      - name: Assert fixture symbols survived LTO
-        working-directory: ct-verify
-        run: |
-          NM=$(find "$(rustc --print sysroot)" -name llvm-nm | head -1)
-          AR=$(find target/${{ matrix.target }}/release -name libct_fixtures.a | head -1)
-          syms=$("$NM" "$AR" | grep -cE '(ct|nct)_fix__') || true
-          echo "fixture symbols: $syms"
-          test "$syms" -ge 3
+        run: cargo run --release -p ct-driver -- --target ${{ matrix.target }}

--- a/ct-verify/Cargo.toml
+++ b/ct-verify/Cargo.toml
@@ -5,7 +5,7 @@
 # `--release` builds. Same isolation pattern as `footprint/*`.
 [workspace]
 resolver = "2"
-members = ["ct-fixtures"]
+members = ["ct-fixtures", "ct-driver"]
 
 # Deterministic codegen: the asm-grep / taint layers must inspect the
 # exact machine code a deployment build emits, and a passing run "locks"

--- a/ct-verify/ct-driver/Cargo.toml
+++ b/ct-verify/ct-driver/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ct-driver"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.87"
+publish = false
+description = "Cross-target disassembly + branch-grep driver for rsa_heapless CT verify."
+
+[[bin]]
+name = "ct-driver"
+path = "src/main.rs"
+
+[dependencies]
+regex = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/ct-verify/ct-driver/src/main.rs
+++ b/ct-verify/ct-driver/src/main.rs
@@ -16,7 +16,7 @@
 //!   2. find the resulting libct_fixtures.a
 //!   3. llvm-objdump --disassemble
 //!   4. assert every ladder-symbol body is branch-free (per-ISA mnemonic
-//!      tables, thumb IT-block aware), and fail closed if no ladder
+//!      tables; an IT-predicated branch still counts), fail closed if no ladder
 //!      symbol is present (inlined away / renamed → can't confirm)
 //!   5. self-test: assert the negative controls still trip the tables
 //!   6. emit JSON report; exit non-zero on any of the above
@@ -157,7 +157,7 @@ fn main() -> ExitCode {
     };
 
     // 3. Disassemble.
-    let objdump_text = match run_objdump(spec, &archive) {
+    let objdump_text = match run_objdump(&archive) {
         Ok(t) => t,
         Err(e) => {
             eprintln!("error: llvm-objdump failed: {}", e);
@@ -177,33 +177,30 @@ fn main() -> ExitCode {
     };
 
     let mut ladder_symbols_matched: usize = 0;
-    let mut ladder_branches: Vec<Violation> = Vec::new();
+    let mut ladder_branches_seen: usize = 0;
+    let mut ladder_violations: Vec<Violation> = Vec::new();
     let mut negative_controls_tripped: usize = 0;
 
     for block in &blocks {
-        // The secret-exponent ladder: at most the reviewed loop-guard
-        // branch, no more.
+        // The secret-exponent ladder: at most the reviewed loop-control
+        // branches, no more. The allowance applies *per block* — if the
+        // ladder is monomorphized for several carriers, each
+        // instantiation gets its own count rather than sharing one pool.
         if ladder_re.is_match(&block.symbol) {
             ladder_symbols_matched += 1;
-            ladder_branches.extend(parse::scan_block(block, spec, &pat));
+            let mut branches = parse::scan_block(block, &pat);
+            ladder_branches_seen += branches.len();
+            if branches.len() > spec.ladder_allowed_branches {
+                ladder_violations.extend(branches.split_off(spec.ladder_allowed_branches));
+            }
             continue;
         }
         // Negative controls: the mnemonic-table self-test. At least one
         // must trip, proving the tables detect branches on this ISA.
-        if parse::is_negative_control(&block.symbol)
-            && !parse::scan_block(block, spec, &pat).is_empty()
-        {
+        if parse::is_negative_control(&block.symbol) && !parse::scan_block(block, &pat).is_empty() {
             negative_controls_tripped += 1;
         }
     }
-
-    // Apply the counted allowance: the reviewed per-ISA count
-    // are the reviewed loop guard; anything beyond is a real finding.
-    let ladder_branches_seen = ladder_branches.len();
-    let ladder_violations: Vec<Violation> = ladder_branches
-        .into_iter()
-        .skip(spec.ladder_allowed_branches)
-        .collect();
 
     // 5. Emit report.
     let report = Report {
@@ -354,15 +351,14 @@ fn llvm_objdump_path() -> Result<PathBuf, String> {
     Ok(PathBuf::from("llvm-objdump"))
 }
 
-fn run_objdump(spec: &TargetSpec, archive: &Path) -> Result<String, String> {
+fn run_objdump(archive: &Path) -> Result<String, String> {
     let tool = llvm_objdump_path()?;
-    let arch_flag = arch_flag_for(spec.triple);
 
+    // No explicit --triple/--arch: llvm-objdump auto-detects the
+    // architecture per-object from the archive's ELF headers, AVR
+    // included (verified identical to an explicit flag).
     let mut cmd = Command::new(&tool);
     cmd.arg("--disassemble").arg("--no-show-raw-insn");
-    if let Some(arch) = arch_flag {
-        cmd.arg(format!("--triple={}", arch));
-    }
     cmd.arg(archive);
 
     let out = cmd.output().map_err(|e| e.to_string())?;
@@ -374,14 +370,4 @@ fn run_objdump(spec: &TargetSpec, archive: &Path) -> Result<String, String> {
         ));
     }
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
-}
-
-fn arch_flag_for(triple: &str) -> Option<&'static str> {
-    // llvm-objdump usually infers the architecture from the object file,
-    // but for some targets (notably AVR) we need to be explicit.
-    if triple.starts_with("avr-") {
-        Some("avr")
-    } else {
-        None
-    }
 }

--- a/ct-verify/ct-driver/src/main.rs
+++ b/ct-verify/ct-driver/src/main.rs
@@ -1,0 +1,387 @@
+//! Ladder branch-freedom check.
+//!
+//! A narrow, targeted check — NOT a whole-operation gate. A whole RSA
+//! sign is full of legitimate branches on public data (padding lengths,
+//! key structure, the public verify exponent, honest-`Option`
+//! boundaries), so asm-grep-for-any-branch produces only false
+//! positives at that granularity; secret-vs-public branch discrimination
+//! is the taint (ctgrind) layer's job. The one thing asm-grep does
+//! prove cheaply is that the **secret-exponent ladder** — the
+//! always-square-always-multiply that raises the message to `d` — emits
+//! zero data-dependent branches, as composed into our archive at our
+//! deployment carrier.
+//!
+//! Per target:
+//!   1. `cargo build --release --target=<triple> -p ct-fixtures`
+//!   2. find the resulting libct_fixtures.a
+//!   3. llvm-objdump --disassemble
+//!   4. assert every ladder-symbol body is branch-free (per-ISA mnemonic
+//!      tables, thumb IT-block aware), and fail closed if no ladder
+//!      symbol is present (inlined away / renamed → can't confirm)
+//!   5. self-test: assert the negative controls still trip the tables
+//!   6. emit JSON report; exit non-zero on any of the above
+
+mod mnemonics;
+mod parse;
+mod report;
+mod target;
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use crate::parse::{Patterns, Violation};
+use crate::report::{Report, ViolationOut};
+use crate::target::{lookup, TargetSpec, TARGETS};
+
+/// Default match for the secret-exponent ladder symbol. modmath's CT
+/// exponentiation is `Field::<T, Ct>::exp`; the mangled form ends
+/// `..Ct$GT$3exp17h<hash>E` (the `3exp` length prefix distinguishes the
+/// bare secret ladder from `14exp_public_exp`, the vartime *public*
+/// exponent used by verify-after-sign). Overridable with `--ladder`.
+const DEFAULT_LADDER: &str = r"Ct\$GT\$3exp17h";
+
+#[derive(Default)]
+struct Args {
+    target: Option<String>,
+    json_out: Option<PathBuf>,
+    list_targets: bool,
+    skip_build: bool,
+    archive_override: Option<PathBuf>,
+    ladder: Option<String>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut args = Args::default();
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--target" => {
+                args.target = Some(it.next().ok_or("--target requires a triple")?);
+            }
+            "--json-out" => {
+                args.json_out = Some(PathBuf::from(
+                    it.next().ok_or("--json-out requires a path")?,
+                ));
+            }
+            "--list-targets" => args.list_targets = true,
+            "--skip-build" => args.skip_build = true,
+            "--archive" => {
+                args.archive_override =
+                    Some(PathBuf::from(it.next().ok_or("--archive requires a path")?));
+            }
+            "--ladder" => {
+                args.ladder = Some(it.next().ok_or("--ladder requires a regex")?);
+            }
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {}", other)),
+        }
+    }
+    Ok(args)
+}
+
+fn print_help() {
+    eprintln!(
+        "ct-driver — disassemble ct-fixtures and gate on forbidden conditional branches.\n\
+         \n\
+         Usage:\n\
+           ct-driver --target <TRIPLE> [--json-out <PATH>] [--skip-build] [--archive <PATH>]\n\
+           ct-driver --list-targets\n\
+           ct-driver -h | --help\n\
+         \n\
+         Options:\n\
+           --target <TRIPLE>   Cargo target triple to verify (use --list-targets for the list).\n\
+                               If omitted, the host triple (rustc -vV → host) is used.\n\
+           --json-out <PATH>   Write JSON report to PATH (also written to stdout in human form).\n\
+           --skip-build        Don't run cargo build; reuse the existing libct_fixtures.a.\n\
+           --archive <PATH>    Override the path to libct_fixtures.a (for debugging).\n\
+         \n\
+         Exit code 0 = clean. Non-zero = ct violations OR negative controls didn't trip."
+    );
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            print_help();
+            return ExitCode::from(2);
+        }
+    };
+
+    if args.list_targets {
+        for t in TARGETS {
+            println!(
+                "[{}] {}  (toolchain: {})",
+                t.priority, t.triple, t.toolchain
+            );
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    let triple = args
+        .target
+        .clone()
+        .unwrap_or_else(|| host_triple().unwrap_or_else(|| "x86_64-unknown-linux-gnu".to_string()));
+
+    let Some(spec) = lookup(&triple) else {
+        eprintln!(
+            "error: unknown target triple '{}'. Use --list-targets to see supported ones.",
+            triple
+        );
+        return ExitCode::from(2);
+    };
+
+    // 1. Build (unless skipped).
+    if !args.skip_build {
+        if let Err(e) = cargo_build_fixtures(spec) {
+            eprintln!("error: cargo build failed: {}", e);
+            return ExitCode::from(3);
+        }
+    }
+
+    // 2. Locate the staticlib.
+    let archive = if let Some(p) = args.archive_override.clone() {
+        p
+    } else {
+        match find_archive(spec) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("error: locating libct_fixtures.a: {}", e);
+                return ExitCode::from(3);
+            }
+        }
+    };
+
+    // 3. Disassemble.
+    let objdump_text = match run_objdump(spec, &archive) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: llvm-objdump failed: {}", e);
+            return ExitCode::from(3);
+        }
+    };
+
+    // 4. Parse + scan.
+    let blocks = parse::split_blocks(&objdump_text);
+    let pat = Patterns::build(spec);
+    let ladder_re = match regex::Regex::new(args.ladder.as_deref().unwrap_or(DEFAULT_LADDER)) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: bad --ladder regex: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let mut ladder_symbols_matched: usize = 0;
+    let mut ladder_branches: Vec<Violation> = Vec::new();
+    let mut negative_controls_tripped: usize = 0;
+
+    for block in &blocks {
+        // The secret-exponent ladder: at most the reviewed loop-guard
+        // branch, no more.
+        if ladder_re.is_match(&block.symbol) {
+            ladder_symbols_matched += 1;
+            ladder_branches.extend(parse::scan_block(block, spec, &pat));
+            continue;
+        }
+        // Negative controls: the mnemonic-table self-test. At least one
+        // must trip, proving the tables detect branches on this ISA.
+        if parse::is_negative_control(&block.symbol)
+            && !parse::scan_block(block, spec, &pat).is_empty()
+        {
+            negative_controls_tripped += 1;
+        }
+    }
+
+    // Apply the counted allowance: the reviewed per-ISA count
+    // are the reviewed loop guard; anything beyond is a real finding.
+    let ladder_branches_seen = ladder_branches.len();
+    let ladder_violations: Vec<Violation> = ladder_branches
+        .into_iter()
+        .skip(spec.ladder_allowed_branches)
+        .collect();
+
+    // 5. Emit report.
+    let report = Report {
+        target: triple.clone(),
+        ladder_symbols_matched,
+        ladder_branches_seen,
+        ladder_branches_allowed: spec.ladder_allowed_branches,
+        negative_controls_tripped,
+        ladder_violations: ladder_violations
+            .into_iter()
+            .map(ViolationOut::from)
+            .collect(),
+    };
+    report.print_human();
+
+    if let Some(path) = args.json_out.as_ref() {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match std::fs::File::create(path) {
+            Ok(f) => {
+                if let Err(e) = serde_json::to_writer_pretty(f, &report) {
+                    eprintln!("warning: writing JSON report failed: {}", e);
+                }
+            }
+            Err(e) => eprintln!("warning: creating JSON report file failed: {}", e),
+        }
+    }
+
+    if report.exit_code() == 0 {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn host_triple() -> Option<String> {
+    let out = Command::new("rustc").arg("-vV").output().ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    for line in s.lines() {
+        if let Some(rest) = line.strip_prefix("host: ") {
+            return Some(rest.trim().to_string());
+        }
+    }
+    None
+}
+
+fn cargo_build_fixtures(spec: &TargetSpec) -> Result<(), String> {
+    let host = host_triple().unwrap_or_default();
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.arg("build")
+        .arg("--release")
+        .arg("-p")
+        .arg("ct-fixtures")
+        // no_std + local panic handler for the staticlib. Not a default
+        // feature: ct-ctgrind links the same crate into a std binary
+        // where a second panic handler would collide.
+        .arg("--features")
+        .arg("panic-handler");
+
+    // Only pass --target if it differs from host (otherwise we end up
+    // building in `target/release/` rather than `target/<triple>/release/`,
+    // which find_archive accounts for, but passing --target=host is also
+    // fine and produces the per-triple path).
+    if spec.triple != host {
+        cmd.arg("--target").arg(spec.triple);
+    }
+    for a in spec.extra_cargo_args {
+        cmd.arg(a);
+    }
+
+    eprintln!(
+        "[ct-driver] cargo {}",
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let status = cmd.status().map_err(|e| e.to_string())?;
+    if !status.success() {
+        return Err(format!("cargo build exited with {}", status));
+    }
+    Ok(())
+}
+
+fn workspace_target_dir() -> PathBuf {
+    // `ct-verify/` is its own nested workspace, so its target dir is
+    // `ct-verify/target/`. We're the member at `ct-verify/ct-driver/`,
+    // so walk up one level to the workspace root and add `target`.
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root = manifest
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or(manifest);
+    root.join("target")
+}
+
+fn find_archive(spec: &TargetSpec) -> Result<PathBuf, String> {
+    let host = host_triple().unwrap_or_default();
+    let target_dir = workspace_target_dir();
+    let archive_subpath = "release/libct_fixtures.a";
+
+    let candidates: Vec<PathBuf> = if spec.triple == host {
+        vec![
+            target_dir.join(archive_subpath),
+            target_dir.join(spec.triple).join(archive_subpath),
+        ]
+    } else {
+        vec![target_dir.join(spec.triple).join(archive_subpath)]
+    };
+
+    for c in &candidates {
+        if c.exists() {
+            return Ok(c.clone());
+        }
+    }
+    Err(format!(
+        "could not find libct_fixtures.a — tried: {}",
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+fn llvm_objdump_path() -> Result<PathBuf, String> {
+    // Prefer the llvm-tools-preview component (matches the toolchain).
+    if let Ok(out) = Command::new("rustc").arg("--print").arg("sysroot").output() {
+        if out.status.success() {
+            let sysroot = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            // The llvm-tools-preview component installs binaries under
+            //   <sysroot>/lib/rustlib/<host>/bin/llvm-objdump
+            let host = host_triple().unwrap_or_default();
+            let candidate = Path::new(&sysroot)
+                .join("lib")
+                .join("rustlib")
+                .join(&host)
+                .join("bin")
+                .join(format!("llvm-objdump{}", std::env::consts::EXE_SUFFIX));
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+    // Fall back to PATH lookup at exec time. If neither name resolves
+    // run_objdump will surface a clear "No such file" error.
+    Ok(PathBuf::from("llvm-objdump"))
+}
+
+fn run_objdump(spec: &TargetSpec, archive: &Path) -> Result<String, String> {
+    let tool = llvm_objdump_path()?;
+    let arch_flag = arch_flag_for(spec.triple);
+
+    let mut cmd = Command::new(&tool);
+    cmd.arg("--disassemble").arg("--no-show-raw-insn");
+    if let Some(arch) = arch_flag {
+        cmd.arg(format!("--triple={}", arch));
+    }
+    cmd.arg(archive);
+
+    let out = cmd.output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err(format!(
+            "llvm-objdump failed: status={} stderr={}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+fn arch_flag_for(triple: &str) -> Option<&'static str> {
+    // llvm-objdump usually infers the architecture from the object file,
+    // but for some targets (notably AVR) we need to be explicit.
+    if triple.starts_with("avr-") {
+        Some("avr")
+    } else {
+        None
+    }
+}

--- a/ct-verify/ct-driver/src/mnemonics.rs
+++ b/ct-verify/ct-driver/src/mnemonics.rs
@@ -1,0 +1,96 @@
+//! Per-architecture forbidden / allowed mnemonic regex tables.
+//!
+//! These are raw regex strings, anchored at start/end of the mnemonic
+//! field (the first whitespace-delimited token after the leading
+//! address on each disassembly line). The parser splits on whitespace
+//! and uses `regex::Regex::is_match` on the mnemonic alone.
+
+// =============================================================================
+// Thumb (Cortex-M0 / M3 / M4 / M7 / M33 / M55) — armv6m, armv7m, armv7em
+// =============================================================================
+//
+// Conditional PC-relative branches: b.eq, b.ne, b.cs, b.hs, b.cc, b.lo,
+//   b.mi, b.pl, b.vs, b.vc, b.hi, b.ls, b.ge, b.lt, b.gt, b.le
+//   — plus the .n / .w width suffixes that llvm-objdump emits.
+// Compare-and-branch: cbz, cbnz (armv7m+ only, not armv6m).
+// Table branch: tbb, tbh (armv7m+ only).
+//
+// Allowed (CT-friendly): IT-block predicate execution. The parser tracks
+// IT state separately and only flags conditional mnemonics that appear
+// *outside* an active IT window.
+
+pub const THUMB_FORBIDDEN: &[&str] = &[
+    r"^b(eq|ne|cs|hs|cc|lo|mi|pl|vs|vc|hi|ls|ge|lt|gt|le)(\.[nw])?$",
+    r"^cbn?z$",
+    r"^tb[bh]$",
+];
+
+pub const THUMB_ALLOWED: &[&str] = &[
+    // IT block headers. Inside the IT window the parser allows the
+    // following conditional mnemonics (handled in parse::it_state).
+    r"^it[te]{0,3}$",
+];
+
+// =============================================================================
+// RISC-V (riscv32imc, riscv32imac, riscv32imafc, etc.)
+// =============================================================================
+//
+// RISC-V has no conditional move or predicate execution. Every branch
+// changes PC. CT code must be xor/and/mask-based; any conditional
+// branch in a Ct primitive is a violation.
+//
+// The gt/le/gtu/leu alternatives cover LLVM-printed pseudo-mnemonic
+// aliases (bgt, ble, bgtu, bleu, bgtz, blez) — `llvm-objdump` prints
+// these by default rather than the canonical bge/blt operand-swapped
+// forms, so a Ct regression that lowered to one of them would
+// otherwise slip past the gate.
+
+pub const RISCV_FORBIDDEN: &[&str] = &[
+    r"^b(eq|ne|lt|ge|gt|le|ltu|geu|gtu|leu)z?$",
+    r"^c\.b(eqz|nez)$",
+];
+
+// =============================================================================
+// AVR (atmega328p)
+// =============================================================================
+//
+// AVR's conditional branches are br<cc>, and there are also "skip next
+// instruction" mnemonics (sbic, sbis, sbrc, sbrs, cpse) — these aren't
+// PC-relative jumps in the usual sense, but they ARE data-dependent
+// control flow (the next instruction may or may not execute), so we
+// flag them.
+
+pub const AVR_FORBIDDEN: &[&str] = &[
+    r"^br(cc|cs|eq|ge|hc|hs|id|ie|lo|lt|mi|ne|pl|sh|tc|ts|vc|vs)$",
+    r"^s(bic|bis|brc|brs)$",
+    r"^cpse$",
+];
+
+// =============================================================================
+// AArch64 (Cortex-A, Apple Silicon, M-series datacenter, etc.)
+// =============================================================================
+//
+// Forbidden: b.<cond>, cbz/cbnz, tbz/tbnz.
+// Allowed: csel / csinc / csinv / csneg / cset / csetm / ccmp / ccmn —
+// the conditional-select family is branch-free and is the CT idiom.
+
+pub const AARCH64_FORBIDDEN: &[&str] = &[
+    r"^b\.(eq|ne|cs|hs|cc|lo|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al|nv)$",
+    r"^cbn?z$",
+    r"^tbn?z$",
+];
+
+pub const AARCH64_ALLOWED: &[&str] = &[r"^cs(el|inc|inv|neg|et|etm)$", r"^ccmp[en]?$", r"^ccmn$"];
+
+// =============================================================================
+// x86_64
+// =============================================================================
+//
+// Forbidden: the full j<cc> family.
+// Allowed: cmov<cc> (conditional-move), set<cc> (flag→byte, branch-free),
+// sbb (subtract-with-borrow, used in the borrow-as-mask idiom).
+
+pub const X86_64_FORBIDDEN: &[&str] =
+    &[r"^j(e|ne|z|nz|a|ae|b|be|c|nc|g|ge|l|le|o|no|s|ns|p|np|pe|po|cxz|ecxz|rcxz)$"];
+
+pub const X86_64_ALLOWED: &[&str] = &[r"^cmov[a-z]+$", r"^set[a-z]+$", r"^sbb[bwlq]?$"];

--- a/ct-verify/ct-driver/src/mnemonics.rs
+++ b/ct-verify/ct-driver/src/mnemonics.rs
@@ -61,7 +61,7 @@ pub const RISCV_FORBIDDEN: &[&str] = &[
 // flag them.
 
 pub const AVR_FORBIDDEN: &[&str] = &[
-    r"^br(cc|cs|eq|ge|hc|hs|id|ie|lo|lt|mi|ne|pl|sh|tc|ts|vc|vs)$",
+    r"^br(cc|cs|eq|ge|hc|hs|id|ie|lo|lt|mi|ne|pl|sh|tc|ts|vc|vs|bs|bc)$",
     r"^s(bic|bis|brc|brs)$",
     r"^cpse$",
 ];

--- a/ct-verify/ct-driver/src/parse.rs
+++ b/ct-verify/ct-driver/src/parse.rs
@@ -163,14 +163,9 @@ impl Patterns {
 }
 
 /// Scan one block for violations, applying the per-target rules.
-pub fn scan_block(block: &FunctionBlock, spec: &TargetSpec, pat: &Patterns) -> Vec<Violation> {
+pub fn scan_block(block: &FunctionBlock, pat: &Patterns) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut recent: VecDeque<String> = VecDeque::with_capacity(3);
-
-    // IT-state machine for thumb. `it_remaining > 0` means the next
-    // `it_remaining` insns are predicated. A forbidden conditional
-    // inside an active IT window is allowed.
-    let mut it_remaining: u32 = 0;
 
     for insn in &block.insns {
         recent.push_back(insn.full_line.clone());
@@ -180,36 +175,19 @@ pub fn scan_block(block: &FunctionBlock, spec: &TargetSpec, pat: &Patterns) -> V
 
         let m = insn.mnemonic.as_str();
 
-        // Thumb IT-block tracking. `it`, `itt`, `ite`, `ittt`, `itte`,
-        // etc. — the trailing t/e letters describe whether the next
-        // 1..4 instructions execute on true or false. We just need the
-        // count.
-        if spec.thumb_it_blocks && m.starts_with("it") && m.len() <= 5 {
-            // it = 1 conditional, itt = 2, ittt = 3, itttt = 4.
-            let n = m.len().saturating_sub(1) as u32; // "it" → 1, "itt" → 2, ...
-            it_remaining = n;
-            continue;
-        }
-
+        // Branchless conditional execution — the CT-safe select. On
+        // Thumb these are the `it`/`itt`/… headers; the predicated
+        // *data-processing* instructions they guard (`moveq`, `addeq`,
+        // …) aren't in any forbidden table, so they fall through and are
+        // ignored. We deliberately do NOT exempt a forbidden mnemonic
+        // just because an IT block is active: an IT-predicated `b<cc>`
+        // is still conditional control flow, and a secret-dependent one
+        // is exactly the leak this gate exists to catch.
         if pat.allowed_matches(m) {
-            // Allowed branchless conditional (csel/cmov/IT etc.) — not a violation.
-            it_remaining = it_remaining.saturating_sub(1);
             continue;
         }
 
         if pat.forbidden_matches(m) {
-            // Forbidden mnemonic. If it's inside an active IT window,
-            // it's actually allowed (predicate execution, branch-free).
-            if it_remaining > 0 {
-                it_remaining -= 1;
-                continue;
-            }
-
-            // Unconditional `b` is also caught by forbidden patterns if
-            // any author adds it there; the default tables don't list
-            // it as forbidden, so we don't special-case it here. The
-            // user-controlled regex set is sovereign.
-
             violations.push(Violation {
                 symbol: block.symbol.clone(),
                 offset: insn.offset,
@@ -217,12 +195,7 @@ pub fn scan_block(block: &FunctionBlock, spec: &TargetSpec, pat: &Patterns) -> V
                 line: insn.full_line.clone(),
                 context: recent.iter().cloned().collect(),
             });
-            continue;
         }
-
-        // Non-conditional instruction (mov, add, ldr, bl, ...). If we
-        // were in an IT window, count it down.
-        it_remaining = it_remaining.saturating_sub(1);
     }
 
     violations

--- a/ct-verify/ct-driver/src/parse.rs
+++ b/ct-verify/ct-driver/src/parse.rs
@@ -1,0 +1,234 @@
+//! Disassembly parser.
+//!
+//! Takes the textual output of `llvm-objdump --disassemble
+//! --no-show-raw-insn --no-leading-addr` and splits it into per-symbol
+//! function blocks. Then for each block runs the per-target mnemonic
+//! check + the thumb IT-state machine + the unconditional-branch
+//! direction classifier.
+
+use std::collections::VecDeque;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::target::TargetSpec;
+
+// Symbol header regex: `<symbol_name>:`. llvm-objdump emits two shapes,
+//   `0000000000000020 <_symbol_name>:`        (without --no-leading-addr)
+//   `<_symbol_name>:`                         (with --no-leading-addr)
+// — both end with `<sym>:`.
+static HEADER_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<([^>]+)>:\s*$").unwrap());
+
+// Instruction line: leading whitespace, then optional `address:`, then the
+// mnemonic, then operands. With --no-leading-addr the address is still
+// emitted (relative). Be permissive: strip the leading `address:` if
+// present, take the first whitespace-delimited token as the mnemonic.
+static INSN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*(?:([0-9a-fA-F]+):)?\s+(\S+)(?:\s+(.*))?$").unwrap());
+
+// Relocation line emitted by `objdump -r`, interleaved with disassembly.
+// Format varies by file format:
+//   Mach-O: `\t\t<addr>:  ARM64_RELOC_BRANCH26\t<symbol>`
+//   ELF:    `\t\t<addr>: R_AARCH64_CALL26\t<symbol>` (and other R_*)
+// Common shape: indented line, optional `addr:`, a relocation type
+// (token containing `RELOC` or starting with `R_`), then a symbol.
+
+/// One disassembled function block.
+#[derive(Debug)]
+pub struct FunctionBlock {
+    pub symbol: String,
+    /// Each line: (offset_hex_string, mnemonic, full_line_text).
+    pub insns: Vec<Insn>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Insn {
+    pub offset: u64,
+    pub mnemonic: String,
+    pub full_line: String,
+}
+
+/// Parse the entire objdump output into function blocks.
+pub fn split_blocks(objdump_out: &str) -> Vec<FunctionBlock> {
+    let mut blocks: Vec<FunctionBlock> = Vec::new();
+    let mut current: Option<FunctionBlock> = None;
+    let mut implicit_offset: u64 = 0;
+
+    for line in objdump_out.lines() {
+        // Skip dividers and headers from the archive listing.
+        if line.is_empty()
+            || line.starts_with("Disassembly")
+            || line.starts_with(';')
+            || line.contains(":\tfile format ")
+        {
+            continue;
+        }
+
+        if let Some(caps) = HEADER_RE.captures(line) {
+            // Flush previous block.
+            if let Some(b) = current.take() {
+                blocks.push(b);
+            }
+            let sym = caps.get(1).unwrap().as_str().to_string();
+            current = Some(FunctionBlock {
+                symbol: sym,
+                insns: Vec::new(),
+            });
+            implicit_offset = 0;
+            continue;
+        }
+
+        let Some(block) = current.as_mut() else {
+            continue;
+        };
+
+        if let Some(caps) = INSN_RE.captures(line) {
+            let offset = if let Some(parsed) = caps
+                .get(1)
+                .and_then(|m| u64::from_str_radix(m.as_str(), 16).ok())
+            {
+                // Keep implicit_offset in sync so a subsequent
+                // address-less line continues from the right place.
+                implicit_offset = parsed + 4;
+                parsed
+            } else {
+                let o = implicit_offset;
+                implicit_offset += 4; // arbitrary default; only used when address column is missing
+                o
+            };
+            let mnemonic = caps
+                .get(2)
+                .map(|m| m.as_str().to_ascii_lowercase())
+                .unwrap_or_default();
+            // Skip lines that aren't actually instructions (e.g.,
+            // `...` continuation lines from llvm-objdump).
+            if mnemonic.is_empty() || mnemonic == "..." {
+                continue;
+            }
+            block.insns.push(Insn {
+                offset,
+                mnemonic,
+                full_line: line.trim_end().to_string(),
+            });
+        }
+    }
+
+    if let Some(b) = current.take() {
+        blocks.push(b);
+    }
+    blocks
+}
+
+/// One detected branch violation.
+#[allow(dead_code)] // `mnemonic` is used by `report.rs::ViolationOut` via `From`.
+#[derive(Debug, Clone)]
+pub struct Violation {
+    pub symbol: String,
+    pub offset: u64,
+    pub mnemonic: String,
+    pub line: String,
+    /// The previous 2 instructions + the violating one, for review.
+    pub context: Vec<String>,
+}
+
+/// Compiled regex set for a target.
+pub struct Patterns {
+    pub forbidden: Vec<Regex>,
+    pub allowed: Vec<Regex>,
+}
+
+impl Patterns {
+    pub fn build(spec: &TargetSpec) -> Self {
+        Self {
+            forbidden: spec
+                .forbidden
+                .iter()
+                .map(|p| Regex::new(p).expect("bad forbidden regex"))
+                .collect(),
+            allowed: spec
+                .allowed_cmov
+                .iter()
+                .map(|p| Regex::new(p).expect("bad allowed regex"))
+                .collect(),
+        }
+    }
+
+    pub fn forbidden_matches(&self, mnemonic: &str) -> bool {
+        self.forbidden.iter().any(|r| r.is_match(mnemonic))
+    }
+
+    pub fn allowed_matches(&self, mnemonic: &str) -> bool {
+        self.allowed.iter().any(|r| r.is_match(mnemonic))
+    }
+}
+
+/// Scan one block for violations, applying the per-target rules.
+pub fn scan_block(block: &FunctionBlock, spec: &TargetSpec, pat: &Patterns) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    let mut recent: VecDeque<String> = VecDeque::with_capacity(3);
+
+    // IT-state machine for thumb. `it_remaining > 0` means the next
+    // `it_remaining` insns are predicated. A forbidden conditional
+    // inside an active IT window is allowed.
+    let mut it_remaining: u32 = 0;
+
+    for insn in &block.insns {
+        recent.push_back(insn.full_line.clone());
+        if recent.len() > 3 {
+            recent.pop_front();
+        }
+
+        let m = insn.mnemonic.as_str();
+
+        // Thumb IT-block tracking. `it`, `itt`, `ite`, `ittt`, `itte`,
+        // etc. — the trailing t/e letters describe whether the next
+        // 1..4 instructions execute on true or false. We just need the
+        // count.
+        if spec.thumb_it_blocks && m.starts_with("it") && m.len() <= 5 {
+            // it = 1 conditional, itt = 2, ittt = 3, itttt = 4.
+            let n = m.len().saturating_sub(1) as u32; // "it" → 1, "itt" → 2, ...
+            it_remaining = n;
+            continue;
+        }
+
+        if pat.allowed_matches(m) {
+            // Allowed branchless conditional (csel/cmov/IT etc.) — not a violation.
+            it_remaining = it_remaining.saturating_sub(1);
+            continue;
+        }
+
+        if pat.forbidden_matches(m) {
+            // Forbidden mnemonic. If it's inside an active IT window,
+            // it's actually allowed (predicate execution, branch-free).
+            if it_remaining > 0 {
+                it_remaining -= 1;
+                continue;
+            }
+
+            // Unconditional `b` is also caught by forbidden patterns if
+            // any author adds it there; the default tables don't list
+            // it as forbidden, so we don't special-case it here. The
+            // user-controlled regex set is sovereign.
+
+            violations.push(Violation {
+                symbol: block.symbol.clone(),
+                offset: insn.offset,
+                mnemonic: insn.mnemonic.clone(),
+                line: insn.full_line.clone(),
+                context: recent.iter().cloned().collect(),
+            });
+            continue;
+        }
+
+        // Non-conditional instruction (mov, add, ldr, bl, ...). If we
+        // were in an IT window, count it down.
+        it_remaining = it_remaining.saturating_sub(1);
+    }
+
+    violations
+}
+
+/// True if a `nct_fix__neg__*` symbol — the negative controls.
+pub fn is_negative_control(sym: &str) -> bool {
+    sym.starts_with("nct_fix__neg__") || sym.starts_with("_nct_fix__neg__")
+}

--- a/ct-verify/ct-driver/src/report.rs
+++ b/ct-verify/ct-driver/src/report.rs
@@ -1,0 +1,95 @@
+//! Report shape (JSON + human) for the ladder branch-freedom check.
+
+use serde::Serialize;
+
+use crate::parse::Violation;
+
+#[derive(Debug, Serialize)]
+pub struct Report {
+    pub target: String,
+    /// Ladder symbols matched (must be ≥ 1; zero means the symbol was
+    /// inlined away or renamed, and we can no longer confirm it).
+    pub ladder_symbols_matched: usize,
+    /// Conditional branches observed across ladder bodies.
+    pub ladder_branches_seen: usize,
+    /// The reviewed-and-documented allowance (the bit-width loop guard).
+    pub ladder_branches_allowed: usize,
+    /// Negative-control symbols that tripped the mnemonic tables (must
+    /// be ≥ 1: proves the tables detect branches on this ISA).
+    pub negative_controls_tripped: usize,
+    /// Branches beyond the documented allowance — each a real finding
+    /// (a candidate secret-dependent branch in the ladder).
+    pub ladder_violations: Vec<ViolationOut>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ViolationOut {
+    pub symbol: String,
+    pub offset: String, // hex
+    pub insn: String,
+    pub context: Vec<String>,
+}
+
+impl From<Violation> for ViolationOut {
+    fn from(v: Violation) -> Self {
+        Self {
+            symbol: v.symbol,
+            offset: format!("0x{:x}", v.offset),
+            insn: v.line.trim().to_string(),
+            context: v.context,
+        }
+    }
+}
+
+impl Report {
+    pub fn exit_code(&self) -> i32 {
+        // Fail closed: a real violation, no ladder symbol to inspect, or
+        // a mnemonic-table self-test that didn't fire.
+        if !self.ladder_violations.is_empty()
+            || self.ladder_symbols_matched == 0
+            || self.negative_controls_tripped == 0
+        {
+            1
+        } else {
+            0
+        }
+    }
+
+    pub fn print_human(&self) {
+        println!("==== ladder-check report for {} ====", self.target);
+        println!(
+            "  ladder symbols matched:    {}",
+            self.ladder_symbols_matched
+        );
+        println!(
+            "  ladder branches:           {} seen, {} allowed (bit-width loop guard)",
+            self.ladder_branches_seen, self.ladder_branches_allowed
+        );
+        println!(
+            "  negative controls tripped: {}",
+            self.negative_controls_tripped
+        );
+        if self.ladder_symbols_matched == 0 {
+            println!("  ✗ no ladder symbol found — cannot confirm the secret-exponent path");
+        }
+        if self.negative_controls_tripped == 0 {
+            println!("  ✗ no negative control tripped — mnemonic tables may be blind on this ISA");
+        }
+        if self.ladder_violations.is_empty() {
+            if self.exit_code() == 0 {
+                println!("  ladder within allowance:   ✓");
+            }
+        } else {
+            println!(
+                "  ladder branches beyond allowance (FORBIDDEN): {}  ✗",
+                self.ladder_violations.len()
+            );
+            for v in &self.ladder_violations {
+                println!("    [{}] {} {}", v.offset, v.symbol, v.insn);
+                for ctx in &v.context {
+                    println!("        | {}", ctx.trim());
+                }
+            }
+        }
+    }
+}

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -1,0 +1,153 @@
+//! Per-target specifications: triple, toolchain pin, and the mnemonic
+//! tables used by the parser.
+
+use crate::mnemonics;
+
+#[allow(dead_code)]
+// `priority` and `toolchain` are documentation-only fields used by
+// `--list-targets`.
+#[derive(Debug, Clone, Copy)]
+pub struct TargetSpec {
+    pub triple: &'static str,
+    pub priority: u8,
+    /// "stable" | "1.86" | "nightly-YYYY-MM-DD". The driver doesn't
+    /// switch toolchains itself — CI sets up the right one and the
+    /// triple drives `cargo build --target=<triple>`. The pin is here
+    /// for documentation and so the driver can warn if the active
+    /// toolchain doesn't match.
+    pub toolchain: &'static str,
+    /// Regexes that, when they match the mnemonic at any insn line of
+    /// any fixture's body, count as a violation.
+    pub forbidden: &'static [&'static str],
+    /// Regexes that, when matched, are explicitly OK even though they
+    /// look conditional. E.g., aarch64 `csel` / x64 `cmovcc` / thumb
+    /// `IT` predicate execution.
+    pub allowed_cmov: &'static [&'static str],
+    /// Engage the thumb IT-state machine.
+    pub thumb_it_blocks: bool,
+    /// Conditional branches the secret-exponent ladder is allowed to
+    /// contain on this ISA — the public bit-width loop control, whose
+    /// operands are compile-time immediates (the const-generic carrier
+    /// width and a loop sentinel), never a secret. Per-arch because the
+    /// loop's back-edge lowering differs: Thumb/AArch64/x86 emit an
+    /// unconditional back-edge (1 conditional guard), RISC-V's
+    /// compare-and-branch emits a conditional back-edge too (2). The
+    /// per-bit multiply is a branchless select on every arch; a count
+    /// beyond this is a candidate secret-dependent branch and fails the
+    /// gate. ctgrind is the semantic authority that the allowed branches
+    /// are secret-independent. Verified by disassembly 2026-07-11.
+    pub ladder_allowed_branches: usize,
+    /// Extra cargo args needed for this target (e.g., `-Z build-std=core`
+    /// for AVR).
+    pub extra_cargo_args: &'static [&'static str],
+}
+
+/// All targets we know how to verify, in priority order.
+pub const TARGETS: &[TargetSpec] = &[
+    // Priority 1: Cortex-M3/M4
+    TargetSpec {
+        triple: "thumbv7em-none-eabi",
+        priority: 1,
+        toolchain: "1.86",
+        forbidden: mnemonics::THUMB_FORBIDDEN,
+        allowed_cmov: mnemonics::THUMB_ALLOWED,
+        thumb_it_blocks: true,
+        ladder_allowed_branches: 1,
+        extra_cargo_args: &[],
+    },
+    TargetSpec {
+        triple: "thumbv7m-none-eabi",
+        priority: 1,
+        toolchain: "1.86",
+        forbidden: mnemonics::THUMB_FORBIDDEN,
+        allowed_cmov: mnemonics::THUMB_ALLOWED,
+        thumb_it_blocks: true,
+        ladder_allowed_branches: 1,
+        extra_cargo_args: &[],
+    },
+    // Priority 2: Cortex-M0
+    TargetSpec {
+        triple: "thumbv6m-none-eabi",
+        priority: 2,
+        toolchain: "1.86",
+        forbidden: mnemonics::THUMB_FORBIDDEN,
+        allowed_cmov: mnemonics::THUMB_ALLOWED,
+        thumb_it_blocks: false, // armv6m has no IT-state machine
+        ladder_allowed_branches: 1,
+        extra_cargo_args: &[],
+    },
+    // Priority 3: 32-bit RISC-V
+    TargetSpec {
+        triple: "riscv32imc-unknown-none-elf",
+        priority: 3,
+        toolchain: "1.86",
+        forbidden: mnemonics::RISCV_FORBIDDEN,
+        allowed_cmov: &[],
+        thumb_it_blocks: false,
+        ladder_allowed_branches: 2,
+        extra_cargo_args: &[],
+    },
+    TargetSpec {
+        triple: "riscv32imac-unknown-none-elf",
+        priority: 3,
+        toolchain: "1.86",
+        forbidden: mnemonics::RISCV_FORBIDDEN,
+        allowed_cmov: &[],
+        thumb_it_blocks: false,
+        ladder_allowed_branches: 2,
+        extra_cargo_args: &[],
+    },
+    // Priority 4: 8-bit AVR (nightly-only, needs build-std + target-cpu).
+    // Modern rustc uses the `avr-none` triple and requires an explicit
+    // `-C target-cpu=<mcu>`. The CI workflow sets RUSTFLAGS accordingly
+    // and passes -Z build-std=core via extra_cargo_args.
+    TargetSpec {
+        triple: "avr-none",
+        priority: 4,
+        toolchain: "nightly",
+        forbidden: mnemonics::AVR_FORBIDDEN,
+        allowed_cmov: &[],
+        thumb_it_blocks: false,
+        ladder_allowed_branches: 1,
+        extra_cargo_args: &["-Z", "build-std=core"],
+    },
+    // Priority 5: aarch64
+    TargetSpec {
+        triple: "aarch64-unknown-linux-gnu",
+        priority: 5,
+        toolchain: "1.86",
+        forbidden: mnemonics::AARCH64_FORBIDDEN,
+        allowed_cmov: mnemonics::AARCH64_ALLOWED,
+        thumb_it_blocks: false,
+        ladder_allowed_branches: 1,
+        extra_cargo_args: &[],
+    },
+    // Priority 6: x86_64
+    TargetSpec {
+        triple: "x86_64-unknown-linux-gnu",
+        priority: 6,
+        toolchain: "1.86",
+        forbidden: mnemonics::X86_64_FORBIDDEN,
+        allowed_cmov: mnemonics::X86_64_ALLOWED,
+        thumb_it_blocks: false,
+        ladder_allowed_branches: 1,
+        extra_cargo_args: &[],
+    },
+    // Host fallback: aarch64-apple-darwin. Same mnemonic tables as
+    // aarch64-linux. The CI matrix doesn't run this; it's here so
+    // `cargo run -p ct-driver` works on macOS dev boxes without --target.
+    TargetSpec {
+        triple: "aarch64-apple-darwin",
+        priority: 99,
+        toolchain: "stable",
+        forbidden: mnemonics::AARCH64_FORBIDDEN,
+        allowed_cmov: mnemonics::AARCH64_ALLOWED,
+        thumb_it_blocks: false,
+        ladder_allowed_branches: 1,
+        extra_cargo_args: &[],
+    },
+];
+
+pub fn lookup(triple: &str) -> Option<&'static TargetSpec> {
+    TARGETS.iter().find(|t| t.triple == triple)
+}

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -23,8 +23,6 @@ pub struct TargetSpec {
     /// look conditional. E.g., aarch64 `csel` / x64 `cmovcc` / thumb
     /// `IT` predicate execution.
     pub allowed_cmov: &'static [&'static str],
-    /// Engage the thumb IT-state machine.
-    pub thumb_it_blocks: bool,
     /// Conditional branches the secret-exponent ladder is allowed to
     /// contain on this ISA — the public bit-width loop control, whose
     /// operands are compile-time immediates (the const-generic carrier
@@ -51,7 +49,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "1.86",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
-        thumb_it_blocks: true,
         ladder_allowed_branches: 1,
         extra_cargo_args: &[],
     },
@@ -61,7 +58,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "1.86",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
-        thumb_it_blocks: true,
         ladder_allowed_branches: 1,
         extra_cargo_args: &[],
     },
@@ -72,7 +68,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "1.86",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
-        thumb_it_blocks: false, // armv6m has no IT-state machine
         ladder_allowed_branches: 1,
         extra_cargo_args: &[],
     },
@@ -83,7 +78,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "1.86",
         forbidden: mnemonics::RISCV_FORBIDDEN,
         allowed_cmov: &[],
-        thumb_it_blocks: false,
         ladder_allowed_branches: 2,
         extra_cargo_args: &[],
     },
@@ -93,7 +87,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "1.86",
         forbidden: mnemonics::RISCV_FORBIDDEN,
         allowed_cmov: &[],
-        thumb_it_blocks: false,
         ladder_allowed_branches: 2,
         extra_cargo_args: &[],
     },
@@ -107,7 +100,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "nightly",
         forbidden: mnemonics::AVR_FORBIDDEN,
         allowed_cmov: &[],
-        thumb_it_blocks: false,
         ladder_allowed_branches: 1,
         extra_cargo_args: &["-Z", "build-std=core"],
     },
@@ -118,7 +110,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "1.86",
         forbidden: mnemonics::AARCH64_FORBIDDEN,
         allowed_cmov: mnemonics::AARCH64_ALLOWED,
-        thumb_it_blocks: false,
         ladder_allowed_branches: 1,
         extra_cargo_args: &[],
     },
@@ -129,7 +120,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "1.86",
         forbidden: mnemonics::X86_64_FORBIDDEN,
         allowed_cmov: mnemonics::X86_64_ALLOWED,
-        thumb_it_blocks: false,
         ladder_allowed_branches: 1,
         extra_cargo_args: &[],
     },
@@ -142,7 +132,6 @@ pub const TARGETS: &[TargetSpec] = &[
         toolchain: "stable",
         forbidden: mnemonics::AARCH64_FORBIDDEN,
         allowed_cmov: mnemonics::AARCH64_ALLOWED,
-        thumb_it_blocks: false,
         ladder_allowed_branches: 1,
         extra_cargo_args: &[],
     },


### PR DESCRIPTION
## Summary

Third CT-verification step — with a **deliberate pivot** the driver run forced.

Copying modmath's whole-operation asm-grep driver and running it against our whole-operation sign fixture proved the model doesn't fit at this granularity: a whole RSA sign is *full* of legitimate branches on public data (padding lengths, key structure, the public verify exponent, the honest-`Option` boundaries). The run flagged **52 branches, all false positives, 0 real leaks**. asm-grep's "any conditional branch is a violation" rule is correct only for *primitive* fixtures where every input is secret — which the fork's scope rule (don't re-test upstream primitives) forbids us from writing. Secret-vs-public branch discrimination at whole-operation scale is the **taint (ctgrind) layer's** job.

So the driver is trimmed to one narrow, targeted check: **the secret-exponent ladder is branch-free except its reviewed public loop control.**

- Targets `Field::<T, Ct>::exp` (the always-square-always-multiply raising the message to `d`), distinguished from the vartime `exp_public_exp` used by verify-after-sign.
- **Per-ISA branch allowance**, each calibrated from disassembly: Thumb/AArch64/x86/AVR = 1 (loop-entry guard), RISC-V = 2 (its compare-and-branch also emits a conditional back-edge). Branch operands are compile-time immediates — the const-generic carrier width (`movw #0x1ff` for `FixedUInt<u8,64>`) and a loop sentinel — never a secret. The per-bit multiply is a branchless `conditional_select` on every arch.
- **Counted allowance, not a whole-symbol skip**: at most the reviewed branches; a regression adding a secret-dependent branch trips it. Verified non-vacuous (allowance→0 fails on the guard).
- **Fails closed** if the ladder symbol is inlined away or renamed; **negative controls** must still trip the mnemonic tables (self-test).

Dropped from modmath's copied driver: the reachability walker, the ~90-entry helper allowlist, and the fixture-body scan.

## Test plan
- [x] Ladder check passes on thumbv7em/7m/6m, riscv32imc/imac, avr-none (calibrated per-ISA)
- [x] Non-vacuous: setting an allowance to 0 trips on the loop guard
- [x] Negative controls trip the mnemonic tables on every ISA
- [x] `cargo build`/`clippy` clean; main crate unaffected (separate workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dedicated CT verification driver that disassembles the fixture archive and enforces a branch-freedom check on the secret-exponent ladder across supported ISAs.

Enhancements:
- Replace the previous fixture-symbol LTO survival check with a targeted ladder branch-freedom gate wired into the CI workflow.
- Add per-target specifications and mnemonic tables to classify conditional branches and allowed branchless conditionals for multiple architectures.
- Implement parsing, scanning, and reporting logic to split objdump output into function blocks, detect forbidden conditional branches, and fail closed when the ladder symbol or negative controls are missing.

Build:
- Extend the ct-verify workspace to include the new ct-driver binary crate used by the CT verification workflow.

CI:
- Update the ct-verify GitHub Actions workflow to run the new ct-driver across the target matrix instead of a simple fixture build and symbol-count check.