### PR TITLE
CT verification: ctgrind taint layer (primary whole-operation gate)

### DIFF
--- a/.github/workflows/ct-ctgrind.yml
+++ b/.github/workflows/ct-ctgrind.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.87.0

--- a/.github/workflows/ct-ctgrind.yml
+++ b/.github/workflows/ct-ctgrind.yml
@@ -1,0 +1,59 @@
+name: CT ctgrind
+
+on:
+  pull_request:
+    paths:
+      - "ct-verify/**"
+      - "src/**"
+      - "Cargo.toml"
+      - ".github/workflows/ct-ctgrind.yml"
+  push:
+    branches:
+      - heapless
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Taint gate: run the whole-operation sign fixture under Valgrind
+  # memcheck with the secret exponent `d` marked undefined. Any
+  # secret-dependent branch or memory access anywhere in the reachable
+  # crypto path — including inlined modmath / fixed-bigint primitives —
+  # trips; the many legitimate branches on public data pass by
+  # construction. This is the primary whole-operation CT gate.
+  #
+  # Both x86_64 and aarch64 from day one: Valgrind supports only these
+  # two Linux archs, and an aarch64 false-pass has bitten this ecosystem
+  # before. The x86_64 row pins +lzcnt,+bmi1 so baseline `leading_zeros`
+  # doesn't lower to a data-dependent branch inside a core intrinsic.
+  ctgrind:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64
+            rustflags: "-C target-feature=+lzcnt,+bmi1"
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+            rustflags: ""
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.87.0
+      - name: Install Valgrind
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq valgrind
+      - name: Build ct-ctgrind
+        working-directory: ct-verify
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+        run: cargo build --release -p ct-ctgrind
+      - name: Taint gate (memcheck)
+        working-directory: ct-verify
+        run: |
+          valgrind --tool=memcheck --error-limit=no --error-exitcode=0 \
+            --suppressions=ct-ctgrind/ct-ctgrind.supp -q \
+            target/release/ct-ctgrind

--- a/ct-verify/Cargo.toml
+++ b/ct-verify/Cargo.toml
@@ -5,7 +5,7 @@
 # `--release` builds. Same isolation pattern as `footprint/*`.
 [workspace]
 resolver = "2"
-members = ["ct-fixtures", "ct-driver"]
+members = ["ct-fixtures", "ct-driver", "ct-ctgrind"]
 
 # Deterministic codegen: the asm-grep / taint layers must inspect the
 # exact machine code a deployment build emits, and a passing run "locks"

--- a/ct-verify/ct-ctgrind/Cargo.toml
+++ b/ct-verify/ct-ctgrind/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ct-ctgrind"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.87"
+publish = false
+description = "Valgrind taint-based CT verifier for the rsa_heapless heapless sign path."
+
+[[bin]]
+name = "ct-ctgrind"
+path = "src/main.rs"
+
+[dependencies]
+# The fixtures as a Rust rlib so this binary can call each `extern "C"`
+# symbol directly. `default-features = false` drops the fixture crate's
+# own `#[panic_handler]` — this binary is std, and std provides one.
+ct-fixtures = { path = "../ct-fixtures", default-features = false }
+
+# Distributed-slice collection for the fixture registry.
+inventory = "0.3"
+
+# Identifier concatenation in macros (for `run_<fixture_name>`).
+paste = "1.0"
+
+# Valgrind client requests; Linux-only — see `src/valgrind.rs`.
+[target.'cfg(target_os = "linux")'.dependencies]
+crabgrind = "0.1"

--- a/ct-verify/ct-ctgrind/Dockerfile
+++ b/ct-verify/ct-ctgrind/Dockerfile
@@ -1,0 +1,37 @@
+# Dev image for iterating on ct-ctgrind locally.
+#
+# Build once (the native arm64 build matches the aarch64 CI row; add
+# --platform linux/amd64 for the x86_64 leg — note that row also sets
+# RUSTFLAGS="-C target-feature=+lzcnt,+bmi1", which SIGILLs inside
+# Valgrind under emulation, so an emulated amd64 run only covers the
+# baseline ISA):
+#   docker build -t ct-ctgrind-dev -f ct-verify/ct-ctgrind/Dockerfile .
+#
+# Then run from the repo root:
+#   docker run --rm -v "$PWD:/work" -w /work \
+#       -e CARGO_TARGET_DIR=/work/target/docker \
+#       ct-ctgrind-dev \
+#       bash -c "cargo build --release -p ct-ctgrind && \
+#                valgrind --tool=memcheck --error-limit=no --error-exitcode=0 -q \
+#                  target/docker/release/ct-ctgrind"
+#
+# Matches the CI image (ubuntu-latest = 24.04) so Valgrind versions and
+# crabgrind's C header dependencies line up.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        build-essential curl valgrind ca-certificates pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --default-toolchain 1.87 --profile minimal --no-modify-path && \
+    rustup --version && cargo --version
+
+WORKDIR /work

--- a/ct-verify/ct-ctgrind/Dockerfile
+++ b/ct-verify/ct-ctgrind/Dockerfile
@@ -7,13 +7,16 @@
 # baseline ISA):
 #   docker build -t ct-ctgrind-dev -f ct-verify/ct-ctgrind/Dockerfile .
 #
-# Then run from the repo root:
-#   docker run --rm -v "$PWD:/work" -w /work \
+# Then run from the repo root (`ct-ctgrind` is a member of the nested
+# `ct-verify` workspace, so build from there and use the workspace's
+# absolute target path):
+#   docker run --rm -v "$PWD:/work" -w /work/ct-verify \
 #       -e CARGO_TARGET_DIR=/work/target/docker \
 #       ct-ctgrind-dev \
 #       bash -c "cargo build --release -p ct-ctgrind && \
-#                valgrind --tool=memcheck --error-limit=no --error-exitcode=0 -q \
-#                  target/docker/release/ct-ctgrind"
+#                valgrind --tool=memcheck --error-limit=no --error-exitcode=0 \
+#                  --suppressions=ct-ctgrind/ct-ctgrind.supp -q \
+#                  /work/target/docker/release/ct-ctgrind"
 #
 # Matches the CI image (ubuntu-latest = 24.04) so Valgrind versions and
 # crabgrind's C header dependencies line up.

--- a/ct-verify/ct-ctgrind/ct-ctgrind.supp
+++ b/ct-verify/ct-ctgrind/ct-ctgrind.supp
@@ -1,0 +1,79 @@
+# Valgrind memcheck suppressions for ct-ctgrind — reviewed, not blanket.
+#
+# Each entry below has been traced to a specific non-leak and is scoped
+# as narrowly as Valgrind frame-matching allows. The load-bearing safety
+# argument for ALL of them: every constant-time-critical primitive is a
+# SEPARATE symbol in the binary — `rsa_private_op_and_check_blinded`,
+# `rsa_private_op_blinded`, `Field::<Ct>::exp` (the secret-exponent
+# ladder), `cios_mont_mul_ct`, `invert_ct`, `try_random_mod`. None of
+# those are inlined into the sign fixture, so a real secret-dependent
+# branch in the crypto path surfaces at one of those symbols and is NOT
+# matched by any suppression here. These only cover byte-plumbing glue.
+#
+# ---------------------------------------------------------------------
+# (1) memcpy / memmove of tainted bytes.
+#
+# The fixture parses the secret exponent from bytes and shuffles
+# secret-derived bytes through padding/serialization, calling
+# memcpy/memmove on tainted memory. glibc's memcpy is *data-oblivious*
+# (it copies bytes regardless of value), but Valgrind's shadow-value
+# propagation through its word-at-a-time SIMD paths is imprecise and
+# reports spurious errors *inside* the memcpy routine. Safe to suppress:
+# memcpy never branches on the data it copies. A secret-dependent
+# *address* would appear in the caller's address computation, a frame
+# above — not matched here.
+{
+   memcpy-internal-cond-on-tainted-data
+   Memcheck:Cond
+   fun:*memcpy*
+}
+{
+   memcpy-internal-value-on-tainted-data
+   Memcheck:Value8
+   fun:*memcpy*
+}
+{
+   memmove-internal-cond-on-tainted-data
+   Memcheck:Cond
+   fun:*memmove*
+}
+{
+   memmove-internal-value-on-tainted-data
+   Memcheck:Value8
+   fun:*memmove*
+}
+
+# ---------------------------------------------------------------------
+# (2) Leading-zero-trim serialization of the PUBLIC RSA signature.
+#
+# The sign path serializes the signature with `uint_to_zeroizing_be_pad`,
+# which trims the value's leading zero bytes (`&buf[leading_zeros..]`)
+# then left-pads to the modulus width — variable-time in the signature's
+# leading-zero count. The RSA signature is secret-*derived* but
+# public-by-design (it is what the caller publishes), so this branch
+# leaks nothing: the whole signature, and hence its leading-zero count,
+# is published. Taint can't see through the "now public" declassification
+# because we can't untaint mid-operation without instrumenting the sign.
+#
+# The trim's slice-bounds check and copy appear as `index_mut` /
+# `copy_from_slice` called from the sign fixture, plus the inlined
+# leading-zeros computation whose innermost frame is the fixture symbol.
+# All three are scoped to the sign fixture as the immediate caller /
+# frame, so they do not suppress slice indexing anywhere else.
+{
+   sig-serialize-trim-index_mut
+   Memcheck:Cond
+   fun:*SliceIndex*index_mut*
+   fun:ct_fix__pkcs1v15_blinded_sign*
+}
+{
+   sig-serialize-trim-copy_from_slice
+   Memcheck:Cond
+   fun:*copy_from_slice*
+   fun:ct_fix__pkcs1v15_blinded_sign*
+}
+{
+   sig-serialize-trim-leading-zeros-inlined
+   Memcheck:Cond
+   fun:ct_fix__pkcs1v15_blinded_sign__fb8__N64
+}

--- a/ct-verify/ct-ctgrind/ct-ctgrind.supp
+++ b/ct-verify/ct-ctgrind/ct-ctgrind.supp
@@ -21,26 +21,33 @@
 # reports spurious errors *inside* the memcpy routine. Safe to suppress:
 # memcpy never branches on the data it copies. A secret-dependent
 # *address* would appear in the caller's address computation, a frame
-# above — not matched here.
+# above — not matched here. Scoped to the sign fixture as the direct
+# caller so a `memcpy` in any *crypto* primitive (all separate symbols)
+# stays fully checked; only the fixture's own byte-parse/serialize
+# copies are suppressed.
 {
-   memcpy-internal-cond-on-tainted-data
+   memcpy-tainted-data-from-sign-fixture-cond
    Memcheck:Cond
    fun:*memcpy*
+   fun:ct_fix__pkcs1v15_blinded_sign*
 }
 {
-   memcpy-internal-value-on-tainted-data
+   memcpy-tainted-data-from-sign-fixture-value
    Memcheck:Value8
    fun:*memcpy*
+   fun:ct_fix__pkcs1v15_blinded_sign*
 }
 {
-   memmove-internal-cond-on-tainted-data
+   memmove-tainted-data-from-sign-fixture-cond
    Memcheck:Cond
    fun:*memmove*
+   fun:ct_fix__pkcs1v15_blinded_sign*
 }
 {
-   memmove-internal-value-on-tainted-data
+   memmove-tainted-data-from-sign-fixture-value
    Memcheck:Value8
    fun:*memmove*
+   fun:ct_fix__pkcs1v15_blinded_sign*
 }
 
 # ---------------------------------------------------------------------

--- a/ct-verify/ct-ctgrind/src/fixtures.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures.rs
@@ -1,0 +1,61 @@
+//! Taint wrappers, one per `ct-fixtures` symbol. Each mirrors its
+//! fixture's ABI one-for-one; extending the fixture set means adding
+//! the symbol there and the matching wrapper here.
+//!
+//! Taint model: the RSA private exponent `d` is the secret. The
+//! modulus `n`, public exponent `e`, and message are public (baked into
+//! the fixture), so they are not tainted — a secret-dependent branch
+//! anywhere in the reachable sign path (including inlined modmath /
+//! fixed-bigint primitives) trips memcheck, while the many legitimate
+//! branches on public lengths / key structure pass by construction.
+//!
+//! The signature output is untainted before we `black_box` it: an RSA
+//! signature is secret-*derived* but public-by-design (it is what the
+//! caller publishes), so reads of it downstream are not leaks.
+
+use crate::macros::{ctgrind_fixture, taint_val, untaint_val};
+use core::hint::black_box;
+
+// Positive: the whole blinded PKCS#1 v1.5 sign at 512-bit, driven by
+// the secret `d`. `ct-fixtures::D_512` is the real private exponent, so
+// the blinded-sign happy path (with verify-after-sign) is what runs;
+// Valgrind's V-bits carry the "secret" mark, the bytes stay real.
+unsafe extern "C" {
+    fn ct_fix__pkcs1v15_blinded_sign__fb8__N64(d_ptr: *const [u8; 64], out_ptr: *mut [u8; 64]);
+}
+ctgrind_fixture!(ct_fix__pkcs1v15_blinded_sign__fb8__N64, {
+    let d = ct_fixtures::D_512;
+    let mut out = [0u8; 64];
+    taint_val(&d);
+    unsafe { ct_fix__pkcs1v15_blinded_sign__fb8__N64(&d, &mut out) }
+    untaint_val(&out);
+    let _ = black_box(out);
+});
+
+// Negative control: a data-dependent branch on the secret bytes. MUST
+// trip — memcheck sees the tainted `if b > 0x7f`.
+unsafe extern "C" {
+    fn nct_fix__neg__secret_branch__fb8__N64(s_ptr: *const [u8; 64], out_ptr: *mut u8);
+}
+ctgrind_fixture!(nct_fix__neg__secret_branch__fb8__N64, {
+    let s = [0u8; 64];
+    let mut out = 0u8;
+    taint_val(&s);
+    unsafe { nct_fix__neg__secret_branch__fb8__N64(&s, &mut out) }
+    untaint_val(&out);
+    let _ = black_box(out);
+});
+
+// Negative control: a non-constant-time (early-exit) comparison on the
+// secret bytes. MUST trip.
+unsafe extern "C" {
+    fn nct_fix__neg__vartime_cmp__fb8__N64(s_ptr: *const [u8; 64], out_ptr: *mut u8);
+}
+ctgrind_fixture!(nct_fix__neg__vartime_cmp__fb8__N64, {
+    let s = [0u8; 64];
+    let mut out = 0u8;
+    taint_val(&s);
+    unsafe { nct_fix__neg__vartime_cmp__fb8__N64(&s, &mut out) }
+    untaint_val(&out);
+    let _ = black_box(out);
+});

--- a/ct-verify/ct-ctgrind/src/fixtures.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures.rs
@@ -33,7 +33,7 @@ ctgrind_fixture!(ct_fix__pkcs1v15_blinded_sign__fb8__N64, {
 });
 
 // Negative control: a data-dependent branch on the secret bytes. MUST
-// trip — memcheck sees the tainted `if b > 0x7f`.
+// trip — memcheck sees the tainted early-exit loop condition.
 unsafe extern "C" {
     fn nct_fix__neg__secret_branch__fb8__N64(s_ptr: *const [u8; 64], out_ptr: *mut u8);
 }

--- a/ct-verify/ct-ctgrind/src/macros.rs
+++ b/ct-verify/ct-ctgrind/src/macros.rs
@@ -1,0 +1,41 @@
+//! Registration macro + taint helpers.
+//!
+//! Every fixture input crosses the C ABI **by pointer** (including the
+//! cswap choice byte), so the taint mark on the pointed-to buffer is
+//! what the callee reads — there is no by-value register copy for the
+//! optimizer to const-propagate past the client request. If a future
+//! fixture takes a by-value scalar, it must be initialized through
+//! `black_box` (see fixed-bigint's `ctgrind_shift` for the failure
+//! mode: release-LTO const-props the literal past `taint_val`, which
+//! only sets Valgrind metadata, not memory contents).
+
+/// Registers `run_<name>` into the inventory. The body is the taint
+/// wrapper: allocate zeroed buffers, `taint*` the secret ones, call the
+/// extern symbol, `untaint*` the outputs, `black_box` them.
+macro_rules! ctgrind_fixture {
+    ($name:ident, $body:block) => {
+        paste::paste! {
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() $body
+            inventory::submit! {
+                crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+pub(crate) use ctgrind_fixture;
+
+// ============================================================================
+// Taint helpers — thin wrappers around crabgrind's memcheck client requests.
+// ============================================================================
+
+pub fn taint_val<T>(v: &T) {
+    crate::valgrind::mark_undefined(v as *const T as *const u8, size_of::<T>());
+}
+
+pub fn untaint_val<T>(v: &T) {
+    crate::valgrind::mark_defined(v as *const T as *const u8, size_of::<T>());
+}

--- a/ct-verify/ct-ctgrind/src/macros.rs
+++ b/ct-verify/ct-ctgrind/src/macros.rs
@@ -1,16 +1,17 @@
 //! Registration macro + taint helpers.
 //!
-//! Every fixture input crosses the C ABI **by pointer** (including the
-//! cswap choice byte), so the taint mark on the pointed-to buffer is
+//! Every fixture input crosses the C ABI **by pointer**, so the taint
+//! mark on the pointed-to buffer is
 //! what the callee reads — there is no by-value register copy for the
 //! optimizer to const-propagate past the client request. If a future
 //! fixture takes a by-value scalar, it must be initialized through
-//! `black_box` (see fixed-bigint's `ctgrind_shift` for the failure
-//! mode: release-LTO const-props the literal past `taint_val`, which
-//! only sets Valgrind metadata, not memory contents).
+//! `black_box` — otherwise release-LTO const-props the literal past
+//! `taint_val`, which only sets Valgrind metadata, not memory contents,
+//! so the taint never reaches the callee.
 
 /// Registers `run_<name>` into the inventory. The body is the taint
-/// wrapper: allocate zeroed buffers, `taint*` the secret ones, call the
+/// wrapper: allocate the input/output buffers, `taint*` the secret
+/// ones, call the
 /// extern symbol, `untaint*` the outputs, `black_box` them.
 macro_rules! ctgrind_fixture {
     ($name:ident, $body:block) => {

--- a/ct-verify/ct-ctgrind/src/main.rs
+++ b/ct-verify/ct-ctgrind/src/main.rs
@@ -1,0 +1,120 @@
+//! ct-ctgrind — Valgrind-based taint verifier for modmath CT primitives.
+//!
+//! Each fixture from `ct-fixtures` is called with its secret inputs
+//! tagged `MAKE_MEM_UNDEFINED` via crabgrind. Valgrind then flags any
+//! conditional jump or memory access that depends on those tainted
+//! bytes. The driver reads Valgrind's error counter between fixtures to
+//! attribute violations.
+//!
+//! Run as: `valgrind --tool=memcheck --error-limit=no --error-exitcode=0 ct-ctgrind`.
+//! `--error-exitcode=0` is important — we want Valgrind to NOT set the
+//! process exit code, because we decide pass/fail ourselves based on
+//! which fixtures (positive or negative) tripped. `--error-limit=no` is
+//! equally load-bearing: memcheck stops collecting after 1,000 distinct
+//! error contexts (or 10M total), and a saturated counter would make
+//! every later fixture read as clean — false passes.
+
+use std::process::ExitCode;
+
+mod macros;
+mod valgrind;
+
+mod fixtures;
+
+pub struct Fixture {
+    pub name: &'static str,
+    pub run: fn(),
+}
+
+inventory::collect!(Fixture);
+
+fn is_positive(name: &str) -> bool {
+    name.starts_with("ct_fix__")
+}
+
+fn is_negative(name: &str) -> bool {
+    name.starts_with("nct_fix__neg__")
+}
+
+fn main() -> ExitCode {
+    // Force the fixtures rlib onto the link line (see `link_anchor`).
+    ct_fixtures::link_anchor();
+
+    if !valgrind::is_under_valgrind() {
+        eprintln!(
+            "error: ct-ctgrind must be run under valgrind \
+             (e.g. `valgrind --tool=memcheck --error-limit=no --error-exitcode=0 ct-ctgrind`)"
+        );
+        return ExitCode::from(2);
+    }
+
+    let mut pos_pass: usize = 0;
+    let mut pos_fail: Vec<&'static str> = Vec::new();
+    let mut neg_seen: usize = 0;
+    let mut neg_no_trip: Vec<&'static str> = Vec::new();
+    let mut unclassified: Vec<&'static str> = Vec::new();
+
+    // inventory's iteration order is link-dependent; sort so reports
+    // are comparable across runs and platforms.
+    let mut fixtures: Vec<&Fixture> = inventory::iter::<Fixture>().collect();
+    fixtures.sort_by_key(|f| f.name);
+
+    for fixture in fixtures {
+        let before = valgrind::count_errors();
+        (fixture.run)();
+        let after = valgrind::count_errors();
+        let tripped = after > before;
+
+        if is_positive(fixture.name) {
+            if tripped {
+                pos_fail.push(fixture.name);
+            } else {
+                pos_pass += 1;
+            }
+        } else if is_negative(fixture.name) {
+            neg_seen += 1;
+            if !tripped {
+                neg_no_trip.push(fixture.name);
+            }
+        } else {
+            // Fail closed — a fixture whose name matches neither prefix is
+            // almost certainly a rename/typo that would otherwise vanish
+            // from coverage silently.
+            unclassified.push(fixture.name);
+        }
+    }
+
+    println!("==== CT-ctgrind report ====");
+    println!(
+        "  ct_fix__*       passed: {}  failed: {}",
+        pos_pass,
+        pos_fail.len()
+    );
+    println!(
+        "  nct_fix__neg__* tripped: {}/{}",
+        neg_seen - neg_no_trip.len(),
+        neg_seen
+    );
+    for f in &pos_fail {
+        println!("    FAIL (positive tripped Valgrind): {}", f);
+    }
+    for f in &neg_no_trip {
+        println!("    FAIL (negative didn't trip): {}", f);
+    }
+    for f in &unclassified {
+        println!("    FAIL (unclassified fixture name): {}", f);
+    }
+
+    if pos_pass + pos_fail.len() == 0 {
+        eprintln!("error: no positive fixtures registered — registry empty?");
+        return ExitCode::FAILURE;
+    }
+    if neg_seen == 0 {
+        eprintln!("error: no negative controls registered — registry empty?");
+        return ExitCode::FAILURE;
+    }
+    if !pos_fail.is_empty() || !neg_no_trip.is_empty() || !unclassified.is_empty() {
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}

--- a/ct-verify/ct-ctgrind/src/main.rs
+++ b/ct-verify/ct-ctgrind/src/main.rs
@@ -1,4 +1,4 @@
-//! ct-ctgrind — Valgrind-based taint verifier for modmath CT primitives.
+//! ct-ctgrind — Valgrind taint verifier for the rsa_heapless heapless sign path.
 //!
 //! Each fixture from `ct-fixtures` is called with its secret inputs
 //! tagged `MAKE_MEM_UNDEFINED` via crabgrind. Valgrind then flags any

--- a/ct-verify/ct-ctgrind/src/valgrind.rs
+++ b/ct-verify/ct-ctgrind/src/valgrind.rs
@@ -1,0 +1,18 @@
+//! Thin abstraction over crabgrind's Valgrind client requests.
+//!
+//! crabgrind links against Valgrind's C headers, which aren't available
+//! outside Linux (Valgrind itself doesn't support macOS aarch64 or Windows).
+//! On non-Linux hosts this module compiles as no-op stubs so the workspace
+//! still builds, but actually exercising the gate requires Linux.
+
+#[cfg(target_os = "linux")]
+mod real;
+
+#[cfg(target_os = "linux")]
+pub use real::*;
+
+#[cfg(not(target_os = "linux"))]
+mod stub;
+
+#[cfg(not(target_os = "linux"))]
+pub use stub::*;

--- a/ct-verify/ct-ctgrind/src/valgrind/real.rs
+++ b/ct-verify/ct-ctgrind/src/valgrind/real.rs
@@ -1,0 +1,31 @@
+//! Linux implementation — real crabgrind calls.
+
+use std::ffi::c_void;
+
+pub fn is_under_valgrind() -> bool {
+    !matches!(crabgrind::run_mode(), crabgrind::RunMode::Native)
+}
+
+pub fn count_errors() -> usize {
+    crabgrind::count_errors()
+}
+
+// A swallowed mark_mem failure would silently untaint a positive
+// fixture into a vacuous pass — fail closed instead.
+pub fn mark_undefined(addr: *const u8, len: usize) {
+    crabgrind::memcheck::mark_mem(
+        addr as *mut c_void,
+        len,
+        crabgrind::memcheck::MemState::Undefined,
+    )
+    .expect("memcheck mark_mem(Undefined) client request failed");
+}
+
+pub fn mark_defined(addr: *const u8, len: usize) {
+    crabgrind::memcheck::mark_mem(
+        addr as *mut c_void,
+        len,
+        crabgrind::memcheck::MemState::Defined,
+    )
+    .expect("memcheck mark_mem(Defined) client request failed");
+}

--- a/ct-verify/ct-ctgrind/src/valgrind/stub.rs
+++ b/ct-verify/ct-ctgrind/src/valgrind/stub.rs
@@ -1,0 +1,13 @@
+//! Non-Linux no-op stubs — see the parent module for the rationale.
+
+pub fn is_under_valgrind() -> bool {
+    false
+}
+
+pub fn count_errors() -> usize {
+    0
+}
+
+pub fn mark_undefined(_addr: *const u8, _len: usize) {}
+
+pub fn mark_defined(_addr: *const u8, _len: usize) {}

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -10,11 +10,12 @@ publish = false
 crate-type = ["staticlib", "rlib"]
 
 [features]
-# The staticlib cross-build is no_std and needs its own panic handler;
-# the rlib link into the (std) taint harness must NOT define one. On by
-# default for the driver; the ctgrind crate depends with
-# `default-features = false`.
-default = ["panic-handler"]
+# `panic-handler` makes the crate `no_std` with its own `#[panic_handler]`,
+# needed for the cross-built staticlib the asm-grep driver disassembles
+# (the driver passes `--features panic-handler` explicitly). Off by
+# default so the ctgrind crate can link this as an rlib into its std
+# binary, where std supplies the panic handler and a second would collide.
+default = []
 panic-handler = []
 
 [dependencies]

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -18,7 +18,7 @@
 //! - `nct_fix__neg__<op>` — a negative control; it MUST trip each gate,
 //!   proving the harness still has teeth.
 
-#![no_std]
+#![cfg_attr(feature = "panic-handler", no_std)]
 
 #[cfg(feature = "panic-handler")]
 #[panic_handler]
@@ -118,9 +118,13 @@ pub unsafe extern "C" fn ct_fix__pkcs1v15_blinded_sign__fb8__N64(
     unsafe { *out_ptr = black_box(sig) }
 }
 
-/// Negative control — data-dependent branch on a secret byte. MUST
-/// trip every gate (asm-grep sees the conditional branch; taint sees
-/// the secret-flagged jump). A clean pass here means the harness is
+/// Negative control — a secret-dependent *early-exit loop*. MUST trip
+/// every gate. A variable-trip-count loop can't be flattened into a
+/// branchless select the way a simple `if x { … }` can (which LLVM
+/// lowers to `csel`/`cmov` — invisible to a taint tool that only sees
+/// conditional *jumps*), so the loop's condition on a tainted byte is a
+/// real conditional jump on every target. Counts leading zero bytes;
+/// the `break` is the branch. A clean pass here means the harness is
 /// broken.
 /// # Safety
 /// `s_ptr` must be a valid, aligned pointer to a 64-byte array;
@@ -131,28 +135,42 @@ pub unsafe extern "C" fn nct_fix__neg__secret_branch__fb8__N64(
     out_ptr: *mut u8,
 ) {
     let s = black_box(unsafe { *s_ptr });
-    let mut acc = 0u8;
-    // Branch whose taken/not-taken depends on secret bytes.
+    let mut n = 0u8;
     for &b in s.iter() {
-        if b > 0x7f {
-            acc = acc.wrapping_add(b);
+        if b != 0 {
+            break;
         }
+        n = n.wrapping_add(1);
     }
-    unsafe { *out_ptr = black_box(acc) }
+    unsafe { *out_ptr = black_box(n) }
 }
 
-/// Negative control — variable-time remainder on a secret dividend.
-/// MUST trip: `%` on a runtime value lowers to a data-dependent
-/// division/branch sequence on every target the driver covers.
+/// Negative control — a non-constant-time comparison (lexicographic,
+/// early-exit on the first differing byte, like a naive `memcmp`). MUST
+/// trip: the early `break` on a tainted byte is a conditional jump that
+/// survives optimization on every target.
 /// # Safety
-/// `s_ptr` must be a valid, aligned pointer to an 8-byte array;
-/// `out_ptr` to a writable `u64`.
+/// `s_ptr` must be a valid, aligned pointer to a 64-byte array;
+/// `out_ptr` to a writable byte.
 #[no_mangle]
-pub unsafe extern "C" fn nct_fix__neg__vartime_rem__fb8__N64(
-    s_ptr: *const [u8; 8],
-    out_ptr: *mut u64,
+pub unsafe extern "C" fn nct_fix__neg__vartime_cmp__fb8__N64(
+    s_ptr: *const [u8; 64],
+    out_ptr: *mut u8,
 ) {
-    let s = u64::from_le_bytes(black_box(unsafe { *s_ptr }));
-    let r = black_box(s) % black_box(0x1_0000_000du64);
-    unsafe { *out_ptr = black_box(r) }
+    let s = black_box(unsafe { *s_ptr });
+    let reference = [0u8; 64];
+    let mut equal = 1u8;
+    for i in 0..64 {
+        if s[i] != reference[i] {
+            equal = 0;
+            break;
+        }
+    }
+    unsafe { *out_ptr = black_box(equal) }
 }
+
+/// No-op that forces this rlib onto a consumer's link line. The taint
+/// harness links `ct-fixtures` as an rlib and calls its `#[no_mangle]`
+/// symbols by name across the C ABI; without a referenced Rust item the
+/// linker may drop the rlib entirely (and with it every fixture symbol).
+pub fn link_anchor() {}


### PR DESCRIPTION
## Summary

Fifth CT step — and post-pivot **the primary CT gate**. Runs the whole blinded PKCS#1 v1.5 sign fixture under Valgrind memcheck with the secret exponent `d` marked undefined. A secret-dependent branch or memory access anywhere in the reachable crypto path — **including inlined modmath / fixed-bigint primitives** — trips; the many legitimate branches on public data (padding lengths, key structure, the public verify exponent, honest-`Option` boundaries) pass by construction. This is the secret-vs-public discrimination the asm-grep layer structurally couldn't do at whole-operation scale.

Harness mechanics mirror modmath's (driver / registration macros / crabgrind wrapper with a non-Linux stub / Dockerfile). The RSA-specific part is the **taint model**: `d` secret, `n`/`e`/message public, the signature output untainted at the boundary (secret-*derived* but public-by-design).

### Two things the real Valgrind run surfaced (and this PR resolves)

- **Negative controls were compiling to branchless `csel` on arm64.** A simple `if x {…}` becomes a conditional *move*, which memcheck doesn't flag (it flags conditional *jumps*), so the negatives didn't trip. Rewrote them as variable-trip-count loops (early `break` on a tainted byte) — can't be flattened, branch on every target, and stay valid asm-grep negatives too.
- **The positive tripped on two non-leaks**, both suppressed with documented, traced entries in `ct-ctgrind.supp`:
  1. **memcpy of tainted bytes** — data-oblivious; a Valgrind shadow-propagation artifact inside glibc memcpy.
  2. **the signature's leading-zero-trim serialization** — variable-time in the signature's leading zeros, but the RSA signature is public, so no leak.

  The load-bearing safety argument for the suppressions: **every CT-critical primitive is a separate symbol** (`rsa_private_op*`, `Field::<Ct>::exp` the ladder, `cios_mont_mul_ct`, `invert_ct`, `try_random_mod`), none inlined into the sign fixture — so a real secret-dependent branch in the crypto surfaces there and is matched by no suppression. The suppressions only cover byte-plumbing glue.

## Test plan
- [x] Verified locally in Docker on **both** x86_64 (emulated baseline) and aarch64: positive passes 1/0, negatives trip 2/2, exit 0
- [x] Ladder check (asm-grep) still green with the rewritten negatives
- [x] `cargo clippy` clean on the new crate; main crate `cargo test --lib` unaffected (separate workspace)
- [x] CI: `ct-ctgrind.yml` on x86_64 (+lzcnt,+bmi1) and aarch64 Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a Valgrind-based ct-ctgrind taint verification binary and CI workflow to gate RSA blinded signing for constant-time behavior, including new taint-wrapped fixtures and negative controls, while adjusting ct-fixtures to support both no_std and std linking scenarios.

New Features:
- Add ct-ctgrind binary that runs ct-fixtures under Valgrind memcheck with tainted secrets to detect secret-dependent control flow or memory access.
- Introduce taint wrapper fixtures and registration macros to model RSA private exponent secrecy and manage Valgrind tainting across fixtures.
- Add a Dockerfile for a reproducible ct-ctgrind development environment and a GitHub Actions workflow to run ct-ctgrind on x86_64 and aarch64.

Enhancements:
- Refine ct-fixtures negative controls to use early-exit loops and comparisons that reliably produce secret-dependent branches on all targets.
- Adjust ct-fixtures crate configuration to make no_std with a custom panic handler optional and ensure rlib linkage via a link anchor function.
- Extend the ct-verify workspace membership to include the new ct-ctgrind crate.

CI:
- Add ct-ctgrind GitHub Actions workflow to run Valgrind-based constant-time taint checks on both x86_64 and aarch64 Linux runners.

Tests:
- Establish Valgrind-based taint tests for the blinded PKCS#1 v1.5 sign path and its negative controls via ct-ctgrind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Valgrind-based constant-time verification for supported cryptographic fixtures.
  * Added positive and negative verification checks for secret-dependent behavior and variable-time comparisons.
  * Added a local container setup for reproducing verification runs.

* **Chores**
  * Automated verification across x86_64 and aarch64 environments.
  * Updated fixture configuration and test coverage for the new checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->