### PR TITLE
CT verification: panic-free sign-path audit (linker-DCE)

### DIFF
--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -48,3 +48,30 @@ jobs:
       - name: Ladder branch-freedom check
         working-directory: ct-verify
         run: cargo run --release -p ct-driver -- --target ${{ matrix.target }}
+
+  # Cross-build the whole heapless sign path as a DCE'd staticlib and
+  # assert the archive links in no `core::panicking` machinery. A
+  # reachable panic in a signer is both a DoS edge and a timing oracle
+  # (panic formatting's cost depends on the values formatted), so the
+  # sign path must resolve every fallible slice/index op to an error
+  # return rather than a panic. Target-invariant in practice (the symbols
+  # are `core::panicking` references), but run on one ARM + one RISC-V
+  # profile to catch any target-specific codegen that reintroduces one.
+  panic-free-audit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - thumbv7m-none-eabi
+          - riscv32imc-unknown-none-elf
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.87.0
+          targets: ${{ matrix.target }}
+          components: llvm-tools-preview
+      - name: Panic-free sign-path audit
+        working-directory: ct-verify
+        run: sh panic-free-audit/check.sh ${{ matrix.target }}

--- a/ct-verify/Cargo.toml
+++ b/ct-verify/Cargo.toml
@@ -5,7 +5,7 @@
 # `--release` builds. Same isolation pattern as `footprint/*`.
 [workspace]
 resolver = "2"
-members = ["ct-fixtures", "ct-driver", "ct-ctgrind"]
+members = ["ct-fixtures", "ct-driver", "ct-ctgrind", "panic-free-audit"]
 
 # Deterministic codegen: the asm-grep / taint layers must inspect the
 # exact machine code a deployment build emits, and a passing run "locks"

--- a/ct-verify/ct-ctgrind/ct-ctgrind.supp
+++ b/ct-verify/ct-ctgrind/ct-ctgrind.supp
@@ -62,25 +62,20 @@
 # is published. Taint can't see through the "now public" declassification
 # because we can't untaint mid-operation without instrumenting the sign.
 #
-# The trim's slice-bounds check and copy appear as `index_mut` /
-# `copy_from_slice` called from the sign fixture, plus the inlined
-# leading-zeros computation whose innermost frame is the fixture symbol.
-# All three are scoped to the sign fixture as the immediate caller /
-# frame, so they do not suppress slice indexing anywhere else.
+# The panic-free serialization path (fallible `get`/`get_mut` slicing +
+# byte-copy loops, no `copy_from_slice`) inlines entirely into the
+# fixture, so the trim's bounds branch surfaces as a Cond and the
+# tainted-offset copy as a Value8 whose innermost frame is the fixture
+# symbol itself. Both entries are scoped to that exact frame, so slice
+# indexing anywhere else — in particular inside any crypto primitive,
+# all separate symbols — stays fully checked.
 {
-   sig-serialize-trim-index_mut
+   sig-serialize-trim-inlined-cond
    Memcheck:Cond
-   fun:*SliceIndex*index_mut*
-   fun:ct_fix__pkcs1v15_blinded_sign*
+   fun:ct_fix__pkcs1v15_blinded_sign__fb8__N64
 }
 {
-   sig-serialize-trim-copy_from_slice
-   Memcheck:Cond
-   fun:*copy_from_slice*
-   fun:ct_fix__pkcs1v15_blinded_sign*
-}
-{
-   sig-serialize-trim-leading-zeros-inlined
-   Memcheck:Cond
+   sig-serialize-trim-inlined-value
+   Memcheck:Value8
    fun:ct_fix__pkcs1v15_blinded_sign__fb8__N64
 }

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "panic-free-audit"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.87"
+publish = false
+description = "Linker-DCE audit: confirm the heapless sign path synthesizes no panic symbols."
+
+[lib]
+# staticlib so a cross-target build produces a `.a` that llvm-nm can
+# read without a linker script or runtime. Same shape as ct-fixtures.
+crate-type = ["staticlib"]
+
+[features]
+default = []
+# See lib.rs — enabled by check.sh for the cross-built staticlib.
+panic-handler = []
+
+[dependencies]
+rsa = { path = "../..", package = "rsa_heapless", default-features = false, features = ["modmath"] }
+fixed-bigint = { version = "0.5.0", default-features = false, features = ["zeroize", "use-unsafe", "cios"] }
+const-num-traits = { version = "0.2.0", default-features = false, features = ["ct"] }
+sha2 = { version = "0.11", default-features = false, features = ["oid"] }
+rand_core = { version = "0.10", default-features = false }
+
+# Workspace [profile.release] (lto=fat, codegen-units=1, opt-level=z,
+# panic=abort) is what makes DCE worth measuring; do not override here.

--- a/ct-verify/panic-free-audit/check.sh
+++ b/ct-verify/panic-free-audit/check.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Panic-free audit: cross-build the audit staticlib and assert no panic
+# machinery was synthesized into it. Usage: check.sh [target-triple]
+# (defaults to thumbv7m-none-eabi; requires the rustup target and the
+# llvm-tools-preview component).
+#
+# The grep targets `core::panicking` entry points. The crate's own
+# `#[panic_handler]` (`rust_begin_unwind`, a lang item) is always emitted
+# and is deliberately NOT matched; what must be absent is anything that
+# reaches core's panic machinery — its presence means some audited path
+# can actually panic.
+set -eu
+
+TARGET="${1:-thumbv7m-none-eabi}"
+HOST="$(rustc -vV | sed -n 's/^host: //p')"
+NM="$(rustc --print sysroot)/lib/rustlib/${HOST}/bin/llvm-nm"
+TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+ARCHIVE="${TARGET_DIR}/${TARGET}/release/libpanic_free_audit.a"
+
+if [ ! -x "$NM" ]; then
+    echo "error: llvm-nm not found at $NM (install the llvm-tools-preview component)" >&2
+    exit 2
+fi
+
+cargo build --release -p panic-free-audit --features panic-handler --target "$TARGET"
+
+FOUND="$("$NM" "$ARCHIVE" | grep -E 'core9panicking|panic_fmt|unwrap_failed|expect_failed|panic_bounds_check|slice_(start|end)_index' || true)"
+if [ -n "$FOUND" ]; then
+    echo "panic machinery found in ${ARCHIVE}:" >&2
+    echo "$FOUND" >&2
+    exit 1
+fi
+echo "OK: no panic symbols in ${ARCHIVE}"

--- a/ct-verify/panic-free-audit/check.sh
+++ b/ct-verify/panic-free-audit/check.sh
@@ -24,7 +24,10 @@ fi
 
 cargo build --release -p panic-free-audit --features panic-handler --target "$TARGET"
 
-FOUND="$("$NM" "$ARCHIVE" | grep -E 'core9panicking|panic_fmt|unwrap_failed|expect_failed|panic_bounds_check|slice_(start|end)_index' || true)"
+# Two steps so a failing llvm-nm aborts via `set -e` (fail closed)
+# instead of vanishing into the `grep || true` pipeline.
+SYMBOLS="$("$NM" "$ARCHIVE")"
+FOUND="$(printf '%s\n' "$SYMBOLS" | grep -E 'core9panicking|panic_fmt|unwrap_failed|expect_failed|panic_bounds_check|slice_(start|end)_index' || true)"
 if [ -n "$FOUND" ]; then
     echo "panic machinery found in ${ARCHIVE}:" >&2
     echo "$FOUND" >&2

--- a/ct-verify/panic-free-audit/src/lib.rs
+++ b/ct-verify/panic-free-audit/src/lib.rs
@@ -1,0 +1,111 @@
+//! Linker-DCE audit for the heapless sign path.
+//!
+//! The `#[no_mangle] pub extern "C"` symbol exercises the whole
+//! heapless PKCS#1 v1.5 sign the way a deployed consumer would: fallible
+//! key construction handled with `if let Ok` (a `match`, never a
+//! panicking `unwrap`), and the sign `Result` observed through
+//! `black_box` rather than extracted. After cross-building with the
+//! workspace release profile, `check.sh` asserts the archive contains
+//! no `core::panicking` machinery — for a signer a reachable panic is
+//! both a DoS edge and a timing oracle (the panic-formatting path's cost
+//! depends on the values being formatted).
+//!
+//! The *prehash* sign variant is used so the digest compression (public,
+//! upstream `sha2`) stays out of the archive; the audit is scoped to
+//! this crate's composition — PKCS#1 v1.5 padding, the blinded private
+//! op, verify-after-sign, and serialization.
+
+// no_std + the local #[panic_handler] only under the `panic-handler`
+// feature (the cross-built audit shape, enabled by check.sh). Host-side
+// workspace builds (clippy) link std, which supplies its own.
+#![cfg_attr(feature = "panic-handler", no_std)]
+
+use const_num_traits::Ct;
+use core::hint::black_box;
+use fixed_bigint::FixedUInt;
+use rsa::modmath_support::public_key_ct_from_be_bytes;
+use rsa::pkcs1v15::GenericSigningKey;
+use rsa::traits::FixedWidthUnsignedInt;
+use rsa::GenericRsaPrivateKey;
+use sha2::Sha256;
+
+type Carrier = FixedUInt<u8, 64, Ct>;
+
+// A real 512-bit RSA keypair (e = 65537), so construction succeeds and
+// the sign path is actually reached rather than skipped by `if let Ok`.
+const N_512: [u8; 64] = [
+    0x9f, 0x7b, 0x0d, 0x2e, 0xfb, 0x10, 0xd4, 0x1b, 0x8c, 0x86, 0x0f, 0x90, 0x67, 0xee, 0xbd, 0xd4,
+    0x72, 0x2d, 0x7e, 0x9f, 0xc2, 0x3b, 0x95, 0x34, 0x33, 0x92, 0x09, 0xf9, 0x0f, 0xa8, 0xf7, 0xed,
+    0xf7, 0x49, 0xd0, 0x42, 0x31, 0xff, 0x52, 0x2e, 0xb0, 0xf6, 0x89, 0xfe, 0xc4, 0x75, 0x35, 0x1c,
+    0x2c, 0x76, 0x53, 0xaa, 0xa1, 0x4a, 0x05, 0xb3, 0xd9, 0x42, 0x6e, 0x41, 0xc4, 0xd8, 0xe4, 0x6f,
+];
+const D_512: [u8; 64] = [
+    0x10, 0x44, 0x80, 0x02, 0xc3, 0xcf, 0x62, 0xa3, 0x70, 0xc1, 0x18, 0x03, 0x55, 0xe6, 0xaf, 0x6c,
+    0x65, 0x3d, 0x28, 0xc6, 0x69, 0x0c, 0xa4, 0xda, 0x8f, 0x4c, 0x1d, 0x42, 0x4f, 0x8b, 0x9f, 0xc6,
+    0x78, 0x0a, 0x6d, 0x42, 0xf4, 0xce, 0x9a, 0x37, 0x83, 0xf5, 0xf4, 0x59, 0x71, 0xb3, 0x8f, 0x5e,
+    0x1b, 0x70, 0xbe, 0xbb, 0x91, 0xd6, 0x74, 0xd8, 0x9c, 0xae, 0xc7, 0xd1, 0x3b, 0x8c, 0xaa, 0x39,
+];
+
+/// Deterministic infallible RNG for the salt/blinding draw — its stream
+/// only needs to be stable, not cryptographic, for a DCE audit.
+struct FixedRng(u64);
+impl rand_core::TryRng for FixedRng {
+    type Error = core::convert::Infallible;
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.try_next_u64()? as u32)
+    }
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        Ok(z ^ (z >> 31))
+    }
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        // Byte-loop fill instead of `copy_from_slice` so the audit
+        // harness's own RNG contributes no `len_mismatch_fail` machinery
+        // to the archive being measured.
+        for chunk in dst.chunks_mut(8) {
+            let bytes = self.try_next_u64()?.to_le_bytes();
+            for (d, s) in chunk.iter_mut().zip(bytes.iter()) {
+                *d = *s;
+            }
+        }
+        Ok(())
+    }
+}
+impl rand_core::TryCryptoRng for FixedRng {}
+
+/// Whole heapless PKCS#1 v1.5 blinded sign, panic-audited: no `unwrap`
+/// on the fallible setup, sign `Result` observed not extracted.
+#[no_mangle]
+pub extern "C" fn panic_audit__pkcs1v15_blinded_sign__fb8__N64(out_ptr: *mut u8) {
+    let d_bytes = black_box(D_512);
+    let prehash = black_box([0u8; 32]); // SHA-256 output width.
+
+    let ok = if let Ok(pubkey) = public_key_ct_from_be_bytes::<Carrier>(&N_512, 65537) {
+        if let Ok(d) = Carrier::try_from_be_bytes_vartime(&d_bytes) {
+            let signing_key = GenericSigningKey::<Sha256, _, _>::new(
+                GenericRsaPrivateKey::from_public_and_d(pubkey, d),
+            );
+            let mut rng = FixedRng(0);
+            let mut em = [0u8; 64];
+            let mut sig = [0u8; 64];
+            signing_key
+                .try_sign_prehash_with_rng_into(&mut rng, &prehash, &mut em, &mut sig)
+                .is_ok()
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    unsafe { *out_ptr = black_box(ok as u8) }
+}
+
+#[cfg(feature = "panic-handler")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/ct-verify/panic-free-audit/src/lib.rs
+++ b/ct-verify/panic-free-audit/src/lib.rs
@@ -91,9 +91,14 @@ pub extern "C" fn panic_audit__pkcs1v15_blinded_sign__fb8__N64(out_ptr: *mut u8)
             let mut rng = FixedRng(0);
             let mut em = [0u8; 64];
             let mut sig = [0u8; 64];
-            signing_key
+            let ok = signing_key
                 .try_sign_prehash_with_rng_into(&mut rng, &prehash, &mut em, &mut sig)
-                .is_ok()
+                .is_ok();
+            // Keep the serialized signature live: with only `is_ok()`
+            // observed, LLVM may DCE the final serialization writes and
+            // the audit would vacuously skip that step.
+            black_box(&sig);
+            ok
         } else {
             false
         }

--- a/src/algorithms/pad.rs
+++ b/src/algorithms/pad.rs
@@ -30,14 +30,26 @@ pub fn left_pad_into<'a>(
         return Err(Error::InvalidPadLen);
     }
 
-    if storage.len() < padded_len {
-        return Err(Error::OutputBufferTooSmall);
-    }
-
     let start = padded_len - input.len();
-    storage[..start].fill(0);
-    storage[start..start + input.len()].copy_from_slice(input);
-    Ok(&storage[..padded_len])
+    {
+        // Fallible slicing (`get_mut`/`split_at_mut_checked`) and a
+        // byte-copy loop instead of `[..]` indexing + `copy_from_slice`,
+        // so no `slice_index_fail` / `copy_from_slice` panic path is
+        // synthesized into the (embedded) sign binary. `tail.len()` ==
+        // `padded_len - start` == `input.len()`, so the zip copies all
+        // of `input`.
+        let region = storage
+            .get_mut(..padded_len)
+            .ok_or(Error::OutputBufferTooSmall)?;
+        let (zeros, tail) = region
+            .split_at_mut_checked(start)
+            .ok_or(Error::InvalidPadLen)?;
+        zeros.fill(0);
+        for (dst, src) in tail.iter_mut().zip(input.iter()) {
+            *dst = *src;
+        }
+    }
+    storage.get(..padded_len).ok_or(Error::OutputBufferTooSmall)
 }
 
 /// Converts input to the new vector of the given length, using BE and with 0s left padded.
@@ -59,7 +71,8 @@ where
     let leading_zeros = input.leading_zeros() as usize / 8;
     let bytes = input.to_be_bytes();
     let borrow: &[u8] = bytes.borrow();
-    left_pad_into(&borrow[leading_zeros..], padded_len, storage)
+    let trimmed = borrow.get(leading_zeros..).ok_or(Error::Internal)?;
+    left_pad_into(trimmed, padded_len, storage)
 }
 
 /// Converts input to the new vector of the given length, using BE and with 0s left padded.
@@ -87,7 +100,8 @@ where
     let m = Zeroizing::new(input);
     let m = Zeroizing::new(m.to_be_bytes());
     let bytes: &[u8] = m.as_ref();
-    left_pad_into(&bytes[leading_zeros..], padded_len, storage)
+    let trimmed = bytes.get(leading_zeros..).ok_or(Error::Internal)?;
+    left_pad_into(trimmed, padded_len, storage)
 }
 
 #[cfg(test)]

--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -173,14 +173,32 @@ pub fn pkcs1v15_sign_pad_into<'a>(
         return Err(Error::MessageTooLong);
     }
 
-    // EM = 0x00 || 0x01 || PS || 0x00 || T
+    // EM = 0x00 || 0x01 || PS || 0x00 || prefix || hashed.
+    // All writes go through fallible `get_mut` + byte-copy loops rather
+    // than `[..]` indexing / `copy_from_slice`, so no `slice_index_fail`
+    // / `copy_from_slice` panic path is synthesized into the (embedded)
+    // sign binary. `k >= t_len + 11` (guarded above), so every index is
+    // in range and no subtraction underflows.
     let em = storage.get_mut(..k).ok_or(Error::OutputBufferTooSmall)?;
-    em[0] = 0;
-    em[1] = 1;
-    em[2..k - t_len - 1].fill(0xff);
-    em[k - t_len - 1] = 0;
-    em[k - t_len..k - hash_len].copy_from_slice(prefix);
-    em[k - hash_len..k].copy_from_slice(hashed);
+    *em.get_mut(0).ok_or(Error::OutputBufferTooSmall)? = 0x00;
+    *em.get_mut(1).ok_or(Error::OutputBufferTooSmall)? = 0x01;
+    em.get_mut(2..k - t_len - 1)
+        .ok_or(Error::OutputBufferTooSmall)?
+        .fill(0xff);
+    *em.get_mut(k - t_len - 1)
+        .ok_or(Error::OutputBufferTooSmall)? = 0x00;
+    let prefix_dst = em
+        .get_mut(k - t_len..k - hash_len)
+        .ok_or(Error::OutputBufferTooSmall)?;
+    for (dst, src) in prefix_dst.iter_mut().zip(prefix.iter()) {
+        *dst = *src;
+    }
+    let hashed_dst = em
+        .get_mut(k - hash_len..k)
+        .ok_or(Error::OutputBufferTooSmall)?;
+    for (dst, src) in hashed_dst.iter_mut().zip(hashed.iter()) {
+        *dst = *src;
+    }
 
     Ok(em)
 }
@@ -330,20 +348,39 @@ where
     let oid = D::OID.as_bytes();
     let oid_len = oid.len() as u8;
     let digest_len = <D as Digest>::output_size() as u8;
+    let total = oid.len() + 10;
+    // Fallible slicing + byte-copy loops (no `[..]` indexing /
+    // `copy_from_slice`) so no `slice_index_fail` / `copy_from_slice`
+    // panic path is synthesized into the (embedded) sign binary.
     let out = storage
-        .get_mut(..oid.len() + 10)
+        .get_mut(..total)
         .ok_or(Error::OutputBufferTooSmall)?;
-    out[..6].copy_from_slice(&[
+    let header = [
         0x30,
         oid_len + 8 + digest_len,
         0x30,
         oid_len + 4,
         0x6,
         oid_len,
-    ]);
-    out[6..6 + oid.len()].copy_from_slice(oid);
-    out[6 + oid.len()..oid.len() + 10].copy_from_slice(&[0x05, 0x00, 0x04, digest_len]);
-    Ok(&out[..oid.len() + 10])
+    ];
+    let head_dst = out.get_mut(..6).ok_or(Error::OutputBufferTooSmall)?;
+    for (dst, src) in head_dst.iter_mut().zip(header.iter()) {
+        *dst = *src;
+    }
+    let oid_dst = out
+        .get_mut(6..6 + oid.len())
+        .ok_or(Error::OutputBufferTooSmall)?;
+    for (dst, src) in oid_dst.iter_mut().zip(oid.iter()) {
+        *dst = *src;
+    }
+    let trailer = [0x05, 0x00, 0x04, digest_len];
+    let tail_dst = out
+        .get_mut(6 + oid.len()..total)
+        .ok_or(Error::OutputBufferTooSmall)?;
+    for (dst, src) in tail_dst.iter_mut().zip(trailer.iter()) {
+        *dst = *src;
+    }
+    out.get(..total).ok_or(Error::OutputBufferTooSmall)
 }
 
 #[cfg(test)]

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -308,8 +308,13 @@ where
         for byte in buf.iter_mut().take(zero_bytes) {
             *byte = 0;
         }
-        if zero_bytes < buf.len() && zero_bits_in_next > 0 {
-            buf[zero_bytes] &= 0xFFu8 >> zero_bits_in_next;
+        if zero_bits_in_next > 0 {
+            // `get_mut` rather than `buf[zero_bytes]` so no
+            // `panic_bounds_check` is synthesized — the index guard is
+            // folded into the `Some` arm.
+            if let Some(b) = buf.get_mut(zero_bytes) {
+                *b &= 0xFFu8 >> zero_bits_in_next;
+            }
         }
         let candidate = <T as FixedWidthUnsignedInt>::try_from_be_bytes_vartime(bytes.as_ref())?;
         let wrapped = wrap(candidate);

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -167,7 +167,7 @@ impl<const N: usize> AsRef<[u8]> for Prefix<N> {
 }
 
 #[cfg(not(feature = "alloc"))]
-pub(super) fn pkcs1v15_generate_prefix_helper<D: Digest>() -> Prefix
+pub(super) fn pkcs1v15_generate_prefix_helper<D>() -> Prefix
 where
     D: Digest + AssociatedOid,
 {

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -139,12 +139,18 @@ impl<const N: usize> Prefix<N> {
     }
 
     pub fn from_slice(input: &[u8]) -> Result<Self> {
-        if input.len() > N {
-            return Err(Error::OutputBufferTooSmall);
-        }
-
         let mut out = Self::new();
-        out.data[..input.len()].copy_from_slice(input);
+        // Fallible `get_mut` + byte-copy loop (no `[..]` indexing /
+        // `copy_from_slice`) so no `slice_index_fail` / `copy_from_slice`
+        // panic path is synthesized into the (embedded) sign binary. The
+        // `get_mut` also subsumes the `input.len() > N` bounds check.
+        let dst = out
+            .data
+            .get_mut(..input.len())
+            .ok_or(Error::OutputBufferTooSmall)?;
+        for (d, s) in dst.iter_mut().zip(input.iter()) {
+            *d = *s;
+        }
         out.len = input.len();
         Ok(out)
     }
@@ -153,7 +159,10 @@ impl<const N: usize> Prefix<N> {
 #[cfg(not(feature = "alloc"))]
 impl<const N: usize> AsRef<[u8]> for Prefix<N> {
     fn as_ref(&self) -> &[u8] {
-        &self.data[..self.len]
+        // `get(..len)` rather than `[..len]` so no `slice_index_fail`
+        // panic path is synthesized; `len <= N` always holds (set only in
+        // `from_slice` after a bounded `get_mut`), so the fallback is dead.
+        self.data.get(..self.len).unwrap_or(&[])
     }
 }
 

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -72,7 +72,15 @@ where
         if bytes.len() > out_len {
             return Err(Error::InvalidArguments);
         }
-        out[out_len - bytes.len()..].copy_from_slice(bytes);
+        // Fallible slice + byte-copy loop rather than `[..]` +
+        // `copy_from_slice`, so no panic path reaches the sign binary;
+        // `dst.len()` == `bytes.len()` by construction.
+        let dst = out
+            .get_mut(out_len - bytes.len()..)
+            .ok_or(Error::InvalidArguments)?;
+        for (d, s) in dst.iter_mut().zip(bytes.iter()) {
+            *d = *s;
+        }
         Ok(NumFromBytes::from_be_bytes(&repr))
     }
 
@@ -105,7 +113,15 @@ where
         if bytes.len() > out_len {
             return Err(Error::InvalidArguments);
         }
-        out[out_len - bytes.len()..].copy_from_slice(bytes);
+        // Fallible slice + byte-copy loop rather than `[..]` +
+        // `copy_from_slice`, so no panic path reaches the sign binary;
+        // `dst.len()` == `bytes.len()` by construction.
+        let dst = out
+            .get_mut(out_len - bytes.len()..)
+            .ok_or(Error::InvalidArguments)?;
+        for (d, s) in dst.iter_mut().zip(bytes.iter()) {
+            *d = *s;
+        }
         Ok(NumFromBytes::from_be_bytes(&repr))
     }
 


### PR DESCRIPTION
Adds the fourth CT-verification layer. The first three (typestate gates, the asm-grep ladder branch-freedom check, the ctgrind taint harness) prove the sign path has no *secret-dependent* control flow. This one proves it has no *panic* control flow at all: a reachable panic in a signer is both a DoS edge and a timing oracle — the panic-formatting path's cost depends on the values being formatted.

## How it works

`ct-verify/panic-free-audit` cross-builds the whole heapless PKCS#1 v1.5 blinded sign as a DCE'd `staticlib` (workspace release profile: fat LTO, `opt-level=z`, `panic=abort`, own `#[panic_handler]` under the `panic-handler` feature). `check.sh` then greps the archive with `llvm-nm` for `core::panicking` entry points. Any reachable `slice_index_fail` / `len_mismatch_fail` / `panic_bounds_check` / `panic_fmt` fails the job.

The *prehash* sign variant is exercised so `sha2` compression (public, upstream) stays out of the archive — the audit is scoped to this crate's composition: PKCS#1 v1.5 padding, the blinded private op, verify-after-sign, and serialization.

## Fixes

The audit surfaced panic paths in fork-owned slice code. Each is rewritten to fallible `get_mut(..)?` / `get(..)?` + byte-copy loops instead of `[..]` indexing / `copy_from_slice` / bare index:

- `pad::left_pad_into` + the BE-trim in `uint_to_{,zeroizing_}be_pad_into`
- `pkcs1v15::pkcs1v15_sign_pad_into` (EM construction)
- `pkcs1v15::pkcs1v15_generate_prefix_into` (DigestInfo prefix)
- `pkcs1v15::Prefix::{from_slice, as_ref}` (heapless prefix holder)
- `traits::modular` `try_from_be_bytes_vartime` (both blanket impls)
- `modmath_support::try_random_mod_masked` (top-byte mask index)

All are fork-added functions in the heapless path; no upstream-shared logic changed. Behavior is identical on the success path — the rewrites only convert would-be panics into the existing `Error` returns.

## CI

New `panic-free-audit` job in `ct-verify.yml`, run across one ARM (`thumbv7m-none-eabi`) and one RISC-V (`riscv32imc-unknown-none-elf`) profile. The result is target-invariant in practice (the symbols are `core::panicking` references), but two profiles catch any target-specific codegen that reintroduces one.

## Summary by Sourcery

Add a CT verification layer that audits the heapless PKCS#1 v1.5 blinded signing path to ensure it is panic-free, and update slice/indexing logic accordingly so fallible operations return errors instead of panicking.

New Features:
- Introduce a panic-free audit crate that cross-builds the heapless signing path as a staticlib and checks the archive for panic-related symbols via llvm-nm.
- Add a deterministic, infallible RNG and a no-std panic handler used exclusively by the panic-free audit harness to exercise the signing path without introducing new panic machinery.

Bug Fixes:
- Eliminate potential panic paths in PKCS#1 v1.5 padding and DigestInfo construction by replacing direct indexing and copy_from_slice calls with fallible slicing and manual byte-copy loops.
- Remove panic-prone slice indexing in left-padding helpers and modular-from-bytes conversions, converting out-of-range accesses into existing error returns instead of panics.
- Avoid bounds-check panics in modular random masking logic by guarding buffer indexing with get_mut and skipping the mask when out of range.

Enhancements:
- Tighten heapless prefix handling to rely on bounded get/get_mut accessors and safe views, ensuring AsRef and constructors do not synthesize panic paths while preserving behavior on valid inputs.

CI:
- Add a panic-free-audit CI job that cross-builds the audit static library for ARM and RISC-V embedded targets and fails if any core::panicking-related symbols are present in the archive.