### PR TITLE
bits() via bit_length(); drop leading_zeros from UnsignedModularInt

### DIFF
--- a/src/algorithms/pad.rs
+++ b/src/algorithms/pad.rs
@@ -68,10 +68,17 @@ pub fn uint_to_be_pad_into<T>(input: T, padded_len: usize, storage: &mut [u8]) -
 where
     T: UnsignedModularInt,
 {
-    let leading_zeros = input.leading_zeros() as usize / 8;
+    // Trim to the value's own bytes via its bit length — value-defined,
+    // so it holds for runtime-length carriers where a "leading zeros of
+    // the container" notion would be ambiguous.
+    let used_bytes = (input.bits() as usize).div_ceil(8);
     let bytes = input.to_be_bytes();
     let borrow: &[u8] = bytes.borrow();
-    let trimmed = borrow.get(leading_zeros..).ok_or(Error::Internal)?;
+    let start = borrow
+        .len()
+        .checked_sub(used_bytes)
+        .ok_or(Error::Internal)?;
+    let trimmed = borrow.get(start..).ok_or(Error::Internal)?;
     left_pad_into(trimmed, padded_len, storage)
 }
 
@@ -96,11 +103,14 @@ where
     T: UnsignedModularInt,
     T::Bytes: zeroize::Zeroize,
 {
-    let leading_zeros = input.leading_zeros() as usize / 8;
+    // Same value-defined trim as `uint_to_be_pad_into`; computed before
+    // `input` moves into the `Zeroizing` wrapper.
+    let used_bytes = (input.bits() as usize).div_ceil(8);
     let m = Zeroizing::new(input);
     let m = Zeroizing::new(m.to_be_bytes());
     let bytes: &[u8] = m.as_ref();
-    let trimmed = bytes.get(leading_zeros..).ok_or(Error::Internal)?;
+    let start = bytes.len().checked_sub(used_bytes).ok_or(Error::Internal)?;
+    let trimmed = bytes.get(start..).ok_or(Error::Internal)?;
     left_pad_into(trimmed, padded_len, storage)
 }
 

--- a/src/modmath_support.rs
+++ b/src/modmath_support.rs
@@ -196,7 +196,7 @@ where
         // type is fixed-width and `resize_unchecked` is a no-op, but the
         // check still needs to reject values that wouldn't survive a
         // narrower precision.
-        let value_bits = self.bits_precision() - self.leading_zeros();
+        let value_bits = self.0.bit_length();
         if value_bits <= at_least_bits_precision {
             Some(self)
         } else {
@@ -211,10 +211,6 @@ where
     T: FixedWidthUnsignedInt + PartialOrd,
 {
     type Bytes = <T as FixedWidthUnsignedInt>::Bytes;
-
-    fn leading_zeros(&self) -> u32 {
-        FixedWidthUnsignedInt::leading_zeros(&self.0)
-    }
 
     fn to_be_bytes(&self) -> Self::Bytes {
         FixedWidthUnsignedInt::to_be_bytes(&self.0)
@@ -236,7 +232,7 @@ where
     }
 
     fn bits(&self) -> u32 {
-        self.bits_precision() - self.leading_zeros()
+        FixedWidthUnsignedInt::bit_length(&self.0)
     }
 
     fn bits_precision(&self) -> u32 {

--- a/src/traits/modular.rs
+++ b/src/traits/modular.rs
@@ -43,6 +43,11 @@ pub trait FixedWidthUnsignedInt: Zeroize + Clone + Copy {
     type Bytes: NumBytes + Default + AsMut<[u8]>;
 
     fn leading_zeros(&self) -> u32;
+    /// Bit length of the value itself (position of the highest set bit;
+    /// 0 for zero) — the value-defined primitive, as opposed to the
+    /// container-relative `leading_zeros`/`bits_precision` pair, which
+    /// only means anything because this trait is fixed-width.
+    fn bit_length(&self) -> u32;
     fn to_be_bytes(&self) -> Self::Bytes;
     fn try_from_be_bytes_vartime(bytes: &[u8]) -> Result<Self>;
     fn bits_precision(&self) -> u32;
@@ -59,6 +64,12 @@ where
 
     fn leading_zeros(&self) -> u32 {
         PrimBits::leading_zeros(*self)
+    }
+
+    fn bit_length(&self) -> u32 {
+        // Width minus leading zeros — valid exactly because this trait
+        // is fixed-width.
+        FixedWidthUnsignedInt::bits_precision(self) - PrimBits::leading_zeros(*self)
     }
 
     fn to_be_bytes(&self) -> Self::Bytes {
@@ -100,6 +111,12 @@ where
 
     fn leading_zeros(&self) -> u32 {
         PrimBits::leading_zeros(*self)
+    }
+
+    fn bit_length(&self) -> u32 {
+        // Width minus leading zeros — valid exactly because this trait
+        // is fixed-width.
+        FixedWidthUnsignedInt::bits_precision(self) - PrimBits::leading_zeros(*self)
     }
 
     fn to_be_bytes(&self) -> Self::Bytes {
@@ -147,7 +164,7 @@ where
         // fixed-width and `resize_unchecked` is a no-op, but the check
         // still needs to reject values that wouldn't survive a narrower
         // precision.
-        let value_bits = self.bits_precision() - self.leading_zeros();
+        let value_bits = self.bit_length();
         if value_bits <= at_least_bits_precision {
             Some(self)
         } else {
@@ -163,10 +180,6 @@ where
 {
     type Bytes = <T as FixedWidthUnsignedInt>::Bytes;
 
-    fn leading_zeros(&self) -> u32 {
-        FixedWidthUnsignedInt::leading_zeros(self)
-    }
-
     fn to_be_bytes(&self) -> Self::Bytes {
         FixedWidthUnsignedInt::to_be_bytes(self)
     }
@@ -176,7 +189,7 @@ where
     }
 
     fn bits(&self) -> u32 {
-        self.bits_precision() - self.leading_zeros()
+        FixedWidthUnsignedInt::bit_length(self)
     }
 
     fn bits_precision(&self) -> u32 {
@@ -207,9 +220,13 @@ pub trait UnsignedModularInt:
     Zeroize + Clone + PartialOrd + IntegerResize<Output = Self> + TryFromBeBytes
 {
     type Bytes: NumBytes + AsMut<[u8]>;
-    fn leading_zeros(&self) -> u32;
     fn to_be_bytes(&self) -> Self::Bytes;
     fn as_nz_ref(&self) -> NonZero<Self>;
+    /// Bit length of the value (position of the highest set bit; 0 for
+    /// zero). A value-defined primitive on purpose: no
+    /// `leading_zeros`-style container-relative accessor lives on this
+    /// trait, so runtime-length carriers can satisfy it without
+    /// committing to any notion of "width".
     fn bits(&self) -> u32;
     fn bits_precision(&self) -> u32;
     #[cfg(feature = "alloc")]
@@ -520,10 +537,6 @@ impl IntegerResize for BoxedUint {
 #[cfg(feature = "alloc")]
 impl UnsignedModularInt for BoxedUint {
     type Bytes = alloc::boxed::Box<[u8]>;
-
-    fn leading_zeros(&self) -> u32 {
-        self.leading_zeros()
-    }
 
     fn to_be_bytes(&self) -> Self::Bytes {
         self.to_be_bytes()


### PR DESCRIPTION
Prep for a runtime-length carrier (HeaplessBigInt): stop computing bit lengths as `bits_precision() - leading_zeros()` on the runtime-capable trait surface. That identity only produces the right answer because the type has a fixed width to subtract from — for a variable-length carrier, "width" is ambiguous (capacity vs current length), and `leading_zeros` on the trait leaks a fixed-width concept into a bound that variable-length values are meant to satisfy.

## Changes

- **`FixedWidthUnsignedInt` gains `bit_length()`** — the value-defined primitive (highest set bit; 0 for zero). Its blanket impls compute width-minus-lz, which is honest exactly there: that trait is definitionally fixed-width.
- **`UnsignedModularInt::bits()` and both `IntegerResize::try_resize` impls** delegate to `bit_length()` instead of the subtraction.
- **`leading_zeros` is removed from `UnsignedModularInt`** (and its three impls: the no-alloc blanket, `ModMathValue<T>`, `BoxedUint`). It stays on `FixedWidthUnsignedInt`, whose one remaining consumer — `try_random_mod`'s masked rejection sampling — genuinely needs the container-relative count.
- **The `pad.rs` BE-trims** (the last `UnsignedModularInt::leading_zeros` callers) now trim to `bits().div_ceil(8)` bytes off the value's own serialized length instead of `leading_zeros / 8` off the container width. Identical arithmetic for byte-aligned fixed widths (`floor((8k−b)/8) ≡ k − ceil(b/8)`), well-defined for variable-length ones. `checked_sub` + `get` keep the panic-free property.

## Verification

CT harness fully re-run since this touches the sign-path serialization: panic audit clean on rustc 1.87 (pinned CI toolchain) and current, both cross targets; taint 4/4 positives with negatives tripping; ladder 4/4 monomorphizations within allowance. Feature powerset, both clippy paths, and the alloc-without-keygen config also pass.

## Semver

Removes a pub trait method and adds a required one — the next release is 0.5.0, not a patch.

## Summary by Sourcery

Introduce value-defined bit length primitives for fixed-width and modular unsigned integers and update padding and resize logic to rely on them instead of container-relative leading-zero counts.

Enhancements:
- Add a bit_length primitive to FixedWidthUnsignedInt and implement it for primitive-backed types.
- Change UnsignedModularInt::bits and IntegerResize implementations to use bit_length rather than bits_precision minus leading_zeros.
- Remove leading_zeros from UnsignedModularInt to support runtime-length carriers without fixed-width assumptions.
- Adjust big-endian padding helpers to trim based on the value’s bit length, keeping behavior for fixed-width types while remaining well-defined for variable-length carriers.