### PR TITLE
Unify hardware CI execution

### DIFF
--- a/.github/actions/krabi-hw-run/action.yml
+++ b/.github/actions/krabi-hw-run/action.yml
@@ -52,6 +52,10 @@ runs:
         export PATH="/usr/local/cargo/bin:$HOME/.cargo/bin:$PATH"
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+        [[ "$KRABI_ACTION_CALIPER_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+          echo "::error::invalid krabi-caliper version: $KRABI_ACTION_CALIPER_VERSION"
+          exit 1
+        }
         expected="krabi-caliper v${KRABI_ACTION_CALIPER_VERSION}:"
         cargo install --list | grep -Fx "$expected" >/dev/null || {
           echo "::error::runner does not provide $expected"

--- a/.github/actions/krabi-hw-run/action.yml
+++ b/.github/actions/krabi-hw-run/action.yml
@@ -1,0 +1,99 @@
+name: Run krabi-caliper hardware campaigns
+description: Load a rig, acquire its host lock, and run prepared or direct campaigns
+
+inputs:
+  rig:
+    description: Rig environment and lock name
+    required: true
+  campaigns:
+    description: Space-separated krabi-caliper campaign names
+    required: true
+  working-directory:
+    description: Campaign workspace relative to the repository root
+    required: false
+    default: .
+  prepared:
+    description: Whether to use prepared campaign manifests
+    required: false
+    default: "false"
+  prepared-root:
+    description: Directory containing one prepared bundle per campaign
+    required: false
+    default: ""
+  rig-directory:
+    description: Mounted directory containing rig environment files
+    required: false
+    default: /rigs
+  lock-timeout-seconds:
+    description: Maximum wait for the host-local rig lock
+    required: false
+    default: "1800"
+  caliper-version:
+    description: Exact krabi-caliper CLI version required in the runner image
+    required: false
+    default: 0.1.3
+
+runs:
+  using: composite
+  steps:
+    - name: Run campaigns on the rig
+      shell: bash
+      env:
+        KRABI_ACTION_RIG: ${{ inputs.rig }}
+        KRABI_ACTION_CAMPAIGNS: ${{ inputs.campaigns }}
+        KRABI_ACTION_WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        KRABI_ACTION_PREPARED: ${{ inputs.prepared }}
+        KRABI_ACTION_PREPARED_ROOT: ${{ inputs.prepared-root }}
+        KRABI_ACTION_RIG_DIRECTORY: ${{ inputs.rig-directory }}
+        KRABI_ACTION_LOCK_TIMEOUT: ${{ inputs.lock-timeout-seconds }}
+        KRABI_ACTION_CALIPER_VERSION: ${{ inputs.caliper-version }}
+      run: |
+        set -euo pipefail
+        export PATH="/usr/local/cargo/bin:$HOME/.cargo/bin:$PATH"
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+        expected="krabi-caliper v${KRABI_ACTION_CALIPER_VERSION}:"
+        cargo install --list | grep -Fx "$expected" >/dev/null || {
+          echo "::error::runner does not provide $expected"
+          cargo install --list
+          exit 1
+        }
+        probe-rs --version
+        if [ -r /sys/fs/cgroup/cpu.max ]; then
+          echo "cpu.max=$(cat /sys/fs/cgroup/cpu.max)"
+        fi
+
+        env_file="${KRABI_ACTION_RIG_DIRECTORY}/${KRABI_ACTION_RIG}.env"
+        [ -f "$env_file" ] || {
+          echo "::error::rig '$KRABI_ACTION_RIG' has no environment file ($env_file)"
+          exit 1
+        }
+        set -a
+        source "$env_file"
+        set +a
+        : "${KRABI_PROBE:?rig $KRABI_ACTION_RIG did not export KRABI_PROBE}"
+        echo "bench=${KRABI_BENCH:-?} rig=${KRABI_RIG:-?} probe=$KRABI_PROBE"
+
+        exec 9>"/run/lock/krabi-rig-$KRABI_ACTION_RIG"
+        flock -w "$KRABI_ACTION_LOCK_TIMEOUT" 9
+
+        probe-rs list | grep -qF "$KRABI_PROBE" || {
+          echo "::error::probe $KRABI_PROBE not attached to ${KRABI_BENCH:-this bench}"
+          exit 1
+        }
+
+        cd "$GITHUB_WORKSPACE/$KRABI_ACTION_WORKING_DIRECTORY"
+        for campaign in $KRABI_ACTION_CAMPAIGNS; do
+          echo "::group::campaign $campaign"
+          if [ "$KRABI_ACTION_PREPARED" = "true" ]; then
+            manifest="$KRABI_ACTION_PREPARED_ROOT/$campaign/manifest.json"
+            [ -f "$manifest" ] || {
+              echo "::error::prepared manifest missing for $campaign ($manifest)"
+              exit 1
+            }
+            cargo krabi-caliper run "$campaign" --prepared "$manifest"
+          else
+            cargo krabi-caliper run "$campaign"
+          fi
+          echo "::endgroup::"
+        done

--- a/.github/workflows/avr.yml
+++ b/.github/workflows/avr.yml
@@ -2,7 +2,9 @@ name: AVR
 
 on:
   push:
-    branches: ["**"]
+    branches:
+      - heapless
+      - 'feature/**'
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - heapless
+      - 'feature/**'
 
 env:
   RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -2,7 +2,9 @@ name: Cortex-M
 
 on:
   push:
-    branches: ["**"]
+    branches:
+      - heapless
+      - 'feature/**'
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/ct-ctgrind.yml
+++ b/.github/workflows/ct-ctgrind.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - heapless
+      - 'feature/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - heapless
+      - 'feature/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/hw-ct.yml
+++ b/.github/workflows/hw-ct.yml
@@ -1,81 +1,17 @@
-# .github/workflows/hw-ct.yml
-# Hardware constant-time measurement on a bench rig (probe-rs + krabi-caliper).
-# GENERIC across repos — only the two strings marked "CHANGE" differ per repo.
 name: hw-ct
 
 on:
   push:
-    branches: [heapless]
+    branches:
+      - heapless
+      - 'feature/**'
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  cyccnt:
-    # CHANGE 1 — the rig-type label. Routes the job to any bench whose runner
-    # advertises this rig; the runner must be registered with this label.
-    runs-on: [self-hosted, rig-stm32f407-dwt]
-
-    # The job only reads the repo; the rig image runs repo build scripts, so keep
-    # the token least-privilege and don't leave it persisted in the checkout.
-    permissions:
-      contents: read
-
-    # Dedicated hardware image from the bench's local registry. --privileged plus
-    # the /dev/bus/usb mount give probe access; /run/lock is the HOST's, so the
-    # flock below serializes across every container that can touch this rig; the
-    # rig .env (the only place a probe serial lives) is mounted read-only.
-    container:
-      image: 127.0.0.1:5000/pi-hw-runner:latest
-      options: --privileged
-      volumes:
-        - /dev/bus/usb:/dev/bus/usb
-        - /run/lock:/run/lock
-        - /srv/krabi-caliper/rigs:/rigs:ro
-
-    env:
-      RIG: stm32f407-dwt                         # CHANGE 1 again (same value, without "rig-")
-      # CHANGE 2 — campaign keys in this repo's krabi-caliper.toml. Two clocks
-      # (~15 min measured): the 768-bit CT gate at 30 MHz / 0 wait states
-      # (deterministic, the real gate) plus a 2048-bit functional smoke at 168 MHz
-      # (not a CT gate).
-      CAMPAIGNS: "rsa768-ct-jtrace-f407-30mhz rsa2048-smoke-jtrace-f407-168mhz"
-      KRABI_RIG_DIR: /rigs                       # where the rig .env is mounted (leave as-is)
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: krabi-caliper on the rig
-        shell: bash
-        working-directory: ct-verify/cyccnt-hardware
-        run: |
-          set -euo pipefail
-          export PATH="/usr/local/cargo/bin:$HOME/.cargo/bin:$PATH"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-          # 1. provider — load the rig's physical facts (KRABI_*) so the campaign
-          #    can expand ${KRABI_PROBE}. The serial lives only in this mounted
-          #    .env, never in the repo.
-          env_file="${KRABI_RIG_DIR:-$HOME/.config/krabi-caliper/rigs}/$RIG.env"
-          [ -f "$env_file" ] || { echo "::error::rig '$RIG' has no env on this bench ($env_file)"; exit 1; }
-          set -a; source "$env_file"; set +a
-          : "${KRABI_PROBE:?rig $RIG did not export KRABI_PROBE}"
-          echo "bench=${KRABI_BENCH:-?} rig=${KRABI_RIG:-?} probe=$KRABI_PROBE"
-
-          # 2. hardware lock — host-local, per rig. Every repo/container that can
-          #    touch this rig blocks here instead of racing for the USB probe.
-          exec 9>"/run/lock/krabi-rig-$RIG"
-          flock -w 1800 9
-
-          # 3. liveness — the declared probe must actually be attached to this
-          #    bench, else fail before flashing (declared != attached).
-          probe-rs list | grep -qF "$KRABI_PROBE" \
-            || { echo "::error::probe $KRABI_PROBE not attached to ${KRABI_BENCH:-this bench}"; exit 1; }
-
-          # 4. run — ${KRABI_PROBE} in the campaign args resolves from the live env.
-          #    Both campaigns run under the single flock so the rig stays serialized.
-          for campaign in $CAMPAIGNS; do
-            echo "::group::campaign $campaign"
-            cargo krabi-caliper run "$campaign"
-            echo "::endgroup::"
-          done
+  hardware:
+    uses: ./.github/workflows/reusable-hw-ct.yml
+    with:
+      campaigns-json: '["rsa768-ct-jtrace-f407-30mhz","rsa2048-smoke-jtrace-f407-168mhz"]'
+      working-directory: ct-verify/cyccnt-hardware
+      prepared: true

--- a/.github/workflows/reusable-hw-ct.yml
+++ b/.github/workflows/reusable-hw-ct.yml
@@ -45,7 +45,7 @@ on:
       timeout-minutes:
         description: Overall hardware-job timeout
         required: false
-        default: 30
+        default: 60
         type: number
       lock-timeout-seconds:
         description: Maximum wait for the host-local rig lock
@@ -99,10 +99,16 @@ jobs:
 
       - name: Install krabi-caliper CLI
         if: steps.caliper-cli-cache.outputs.cache-hit != 'true'
+        env:
+          CALIPER_VERSION: ${{ inputs.caliper-version }}
         run: |
+          [[ "$CALIPER_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+            echo "::error::invalid krabi-caliper version: $CALIPER_VERSION"
+            exit 1
+          }
           cargo install \
             krabi-caliper \
-            --version "=${{ inputs.caliper-version }}" \
+            --version "=$CALIPER_VERSION" \
             --locked \
             --features cli,campaign
 

--- a/.github/workflows/reusable-hw-ct.yml
+++ b/.github/workflows/reusable-hw-ct.yml
@@ -1,0 +1,168 @@
+name: reusable-hw-ct
+
+on:
+  workflow_call:
+    inputs:
+      campaigns-json:
+        description: JSON array of krabi-caliper campaign names
+        required: true
+        type: string
+      working-directory:
+        description: Campaign workspace relative to the repository root
+        required: false
+        default: .
+        type: string
+      prepared:
+        description: Build relocatable campaign bundles on a hosted runner
+        required: false
+        default: false
+        type: boolean
+      build-target:
+        description: Rust target required to build prepared firmware
+        required: false
+        default: thumbv7em-none-eabihf
+        type: string
+      rig:
+        description: Rig environment and lock name
+        required: false
+        default: stm32f407-dwt
+        type: string
+      runner-labels-json:
+        description: JSON array of self-hosted runner labels
+        required: false
+        default: '["self-hosted","rig-stm32f407-dwt"]'
+        type: string
+      container-image:
+        description: Hardware job image
+        required: false
+        default: 127.0.0.1:5000/pi-hw-runner:caliper-0.1.3
+        type: string
+      container-options:
+        description: Docker options for probe access and CPU control
+        required: false
+        default: --privileged --cpus 3.2
+        type: string
+      timeout-minutes:
+        description: Overall hardware-job timeout
+        required: false
+        default: 30
+        type: number
+      lock-timeout-seconds:
+        description: Maximum wait for the host-local rig lock
+        required: false
+        default: 1800
+        type: number
+      caliper-version:
+        description: Exact krabi-caliper CLI version used for build and run
+        required: false
+        default: 0.1.3
+        type: string
+
+concurrency:
+  group: hw-ct-${{ github.repository }}-${{ inputs.rig }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: inputs.prepared
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CAMPAIGNS: ${{ join(fromJSON(inputs.campaigns-json), ' ') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ inputs.build-target }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ inputs.working-directory }}/target
+          key: hw-ct-build-${{ inputs.caliper-version }}-${{ hashFiles(format('{0}/Cargo.toml', inputs.working-directory), format('{0}/Cargo.lock', inputs.working-directory), format('{0}/krabi-caliper.toml', inputs.working-directory)) }}
+          restore-keys: hw-ct-build-${{ inputs.caliper-version }}-
+
+      - name: Restore krabi-caliper CLI
+        id: caliper-cli-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-krabi-caliper
+            ~/.cargo/bin/krabi-caliper-simavr
+          key: caliper-cli-${{ runner.os }}-${{ runner.arch }}-${{ inputs.caliper-version }}
+
+      - name: Install krabi-caliper CLI
+        if: steps.caliper-cli-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install \
+            krabi-caliper \
+            --version "=${{ inputs.caliper-version }}" \
+            --locked \
+            --features cli,campaign
+
+      - name: Save krabi-caliper CLI
+        if: steps.caliper-cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-krabi-caliper
+            ~/.cargo/bin/krabi-caliper-simavr
+          key: caliper-cli-${{ runner.os }}-${{ runner.arch }}-${{ inputs.caliper-version }}
+
+      - name: Build prepared campaigns
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+          for campaign in $CAMPAIGNS; do
+            cargo krabi-caliper build \
+              "$campaign" \
+              --output "$RUNNER_TEMP/prepared/$campaign"
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: krabi-hw-prepared-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/prepared
+          if-no-files-found: error
+          retention-days: 3
+
+  hardware:
+    needs: build
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    runs-on: ${{ fromJSON(inputs.runner-labels-json) }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    container:
+      image: ${{ inputs.container-image }}
+      options: ${{ inputs.container-options }}
+      volumes:
+        - /dev/bus/usb:/dev/bus/usb
+        - /run/lock:/run/lock
+        - /srv/krabi-caliper/rigs:/rigs:ro
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        if: inputs.prepared
+        with:
+          name: krabi-hw-prepared-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/prepared
+
+      - uses: ./.github/actions/krabi-hw-run
+        with:
+          rig: ${{ inputs.rig }}
+          campaigns: ${{ join(fromJSON(inputs.campaigns-json), ' ') }}
+          working-directory: ${{ inputs.working-directory }}
+          prepared: ${{ inputs.prepared }}
+          prepared-root: ${{ runner.temp }}/prepared
+          lock-timeout-seconds: ${{ inputs.lock-timeout-seconds }}
+          caliper-version: ${{ inputs.caliper-version }}

--- a/.github/workflows/reusable-hw-ct.yml
+++ b/.github/workflows/reusable-hw-ct.yml
@@ -133,7 +133,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: krabi-hw-prepared-${{ github.run_id }}-${{ github.run_attempt }}
+          name: krabi-hw-prepared-${{ github.run_id }}
           path: ${{ runner.temp }}/prepared
           if-no-files-found: error
           retention-days: 3
@@ -160,7 +160,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: inputs.prepared
         with:
-          name: krabi-hw-prepared-${{ github.run_id }}-${{ github.run_attempt }}
+          name: krabi-hw-prepared-${{ github.run_id }}
           path: ${{ runner.temp }}/prepared
 
       - uses: ./.github/actions/krabi-hw-run

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -2,7 +2,9 @@ name: RISC-V
 
 on:
   push:
-    branches: ["**"]
+    branches:
+      - heapless
+      - 'feature/**'
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -5,7 +5,9 @@ on:
     paths-ignore:
       - README.md
   push:
-    branches: master
+    branches:
+      - heapless
+      - 'feature/**'
     paths-ignore:
       - README.md
 


### PR DESCRIPTION
## Summary

- prepare both RSA hardware campaigns on a hosted runner before acquiring the F407 rig
- preserve the 30 MHz RSA-768 CT gate and 168 MHz RSA-2048 smoke split
- use the common local hardware workflow with a 3.2-CPU cap and immutable caliper 0.1.3 image
- restrict build and verification push triggers to `heapless` and `feature/**` while retaining PR, manual, and scheduled runs

## Validation

- built both prepared campaign bundles with crates.io krabi-caliper 0.1.3
- repository pre-commit suite
- parsed all workflow and action YAML files
- confirmed shared action and reusable workflow hashes match fixed-bigint

## Summary by Sourcery

Introduce a reusable hardware constant-time workflow and action, and align CI triggers and hardware jobs to a common branch policy.

New Features:
- Add a reusable hw-ct workflow that can optionally pre-build relocatable krabi-caliper campaign bundles on hosted runners before hardware execution.
- Add a composite krabi-hw-run GitHub Action to encapsulate rig loading, locking, and running prepared or direct hardware campaigns.

Enhancements:
- Refactor the hw-ct workflow to delegate hardware execution to the reusable hw-ct workflow while preserving existing RSA hardware campaigns and working directory configuration.
- Configure hardware jobs to use a fixed caliper 0.1.3 container image with controlled CPU allocation for consistent measurements.

CI:
- Restrict push-based CI, build, and verification workflows to the heapless and feature/** branches while keeping pull request, manual, and scheduled runs intact.